### PR TITLE
Dgtf 997 add ham to threadfix zap plugin

### DIFF
--- a/threadfix-scanner-plugin/zaproxy/assembly/assembly.xml
+++ b/threadfix-scanner-plugin/zaproxy/assembly/assembly.xml
@@ -1,0 +1,29 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.2 http://maven.apache.org/xsd/assembly-1.1.2.xsd">
+    <id>assembly</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <excludes>
+                <exclude>log4j:log4j</exclude>
+                <exclude>commons-httpclient:commons-httpclient</exclude>
+            </excludes>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <useStrictFiltering>true</useStrictFiltering>
+            <outputDirectory>/</outputDirectory>
+            <directory>src/org/zaproxy/zap/extension/threadfix</directory>
+            <includes>
+                <include>ZapAddOn.xml</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/threadfix-scanner-plugin/zaproxy/assembly/zap.xml
+++ b/threadfix-scanner-plugin/zaproxy/assembly/zap.xml
@@ -13,17 +13,33 @@
             <outputDirectory>/</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <unpack>true</unpack>
+            <unpackOptions>
+                <excludes>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.SF</exclude>
+                </excludes>
+            </unpackOptions>
             <scope>runtime</scope>
         </dependencySet>
     </dependencySets>
     <fileSets>
         <fileSet>
-            <useStrictFiltering>true</useStrictFiltering>
             <outputDirectory>/</outputDirectory>
-            <directory>src/org/zaproxy/zap/extension/threadfix</directory>
+            <directory>src/org/zaproxy/zap/extension/${zap.extension.name}</directory>
             <includes>
                 <include>ZapAddOn.xml</include>
             </includes>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>org/zaproxy/zap/extension/${zap.extension.name}/</outputDirectory>
+            <directory>src/org/zaproxy/zap/extension/${zap.extension.name}</directory>
+            <includes>
+                <include>Messages*</include>
+            </includes>
+        </fileSet>
+        <fileSet>
+            <outputDirectory>org/zaproxy/zap/extension/${zap.extension.name}/resources/</outputDirectory>
+            <directory>src/org/zaproxy/zap/extension/${zap.extension.name}/resources</directory>
         </fileSet>
     </fileSets>
 </assembly>

--- a/threadfix-scanner-plugin/zaproxy/pom.xml
+++ b/threadfix-scanner-plugin/zaproxy/pom.xml
@@ -50,14 +50,15 @@
             </plugin>
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>assembly/zap.xml</descriptor>
+                    </descriptors>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <finalName>${zap.extension.name}-${zap.extension.type}-${zap.extension.version}.zap</finalName>
+                </configuration>
                 <executions>
                     <execution>
-                        <configuration>
-                            <descriptors>
-                                <descriptor>assembly/assembly.xml</descriptor>
-                            </descriptors>
-                            <finalName>threadfix-release-1.zap</finalName>
-                        </configuration>
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
@@ -76,7 +77,7 @@
                         </goals>
                         <configuration>
                             <tasks>
-                                <move file="target/threadfix-release-1.zap-assembly.jar" tofile="target/threadfix-release-1.zap"/>
+                                <move file="target/${zap.extension.name}-${zap.extension.type}-${zap.extension.version}.zap.jar" tofile="target/${zap.extension.name}-${zap.extension.type}-${zap.extension.version}.zap"/>
                             </tasks>
                         </configuration>
                     </execution>
@@ -336,6 +337,10 @@
     </dependencies>
 
     <properties>
+        <zap.extension.name>threadfix</zap.extension.name>
+        <zap.extension.type>release</zap.extension.type>
+        <zap.extension.version>1</zap.extension.version>
+
         <db.name>stonemill</db.name>
 
         <!-- Framework dependency versions -->

--- a/threadfix-scanner-plugin/zaproxy/pom.xml
+++ b/threadfix-scanner-plugin/zaproxy/pom.xml
@@ -334,12 +334,17 @@
             <artifactId>threadfix-entities</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.denimgroup.threadfix</groupId>
+            <artifactId>threadfix-ham</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <properties>
         <zap.extension.name>threadfix</zap.extension.name>
         <zap.extension.type>release</zap.extension.type>
-        <zap.extension.version>1</zap.extension.version>
+        <zap.extension.version>2</zap.extension.version>
 
         <db.name>stonemill</db.name>
 

--- a/threadfix-scanner-plugin/zaproxy/pom.xml
+++ b/threadfix-scanner-plugin/zaproxy/pom.xml
@@ -53,19 +53,32 @@
                 <executions>
                     <execution>
                         <configuration>
-                            <archive>
-                                <manifest>
-                                    <mainClass>test</mainClass>
-                                </manifest>
-                            </archive>
-                            <descriptorRefs>
-                                <descriptorRef>jar-with-dependencies</descriptorRef>
-                            </descriptorRefs>
+                            <descriptors>
+                                <descriptor>assembly/assembly.xml</descriptor>
+                            </descriptors>
+                            <finalName>threadfix-release-1.zap</finalName>
                         </configuration>
                         <phase>package</phase>
                         <goals>
                             <goal>single</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>PackageRename</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <move file="target/threadfix-release-1.zap-assembly.jar" tofile="target/threadfix-release-1.zap"/>
+                            </tasks>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/EndpointsAction.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/EndpointsAction.java
@@ -69,8 +69,9 @@ public abstract class EndpointsAction extends JMenuItem {
 	                } else {
 
                         getLogger().info("Got " + endpoints.length + " endpoints.");
-	
+
 		                for (Endpoint.Info endpoint : endpoints) {
+		                    getLogger().debug("  " + endpoint.getCsvLine());
 		                    if (endpoint != null) {
 
 		                    	String urlPath = endpoint.getUrlPath();

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/ImportAction.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/ImportAction.java
@@ -39,7 +39,7 @@ import org.zaproxy.zap.extension.threadfix.ZapPropertiesManager;
 
 public class ImportAction extends JMenuItem {
 
-	private static final long serialVersionUID = 7496536214677590654L;
+	private static final long serialVersionUID = 1L;
 	
 	private static final Logger logger = Logger.getLogger(ImportAction.class);
 

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/ImportAction.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/ImportAction.java
@@ -44,14 +44,14 @@ public class ImportAction extends JMenuItem {
 	private static final Logger logger = Logger.getLogger(ImportAction.class);
 
     public ImportAction(final ViewDelegate view, final Model model) {
-        logger.info("Initializing ThreadFix scan export menu item");
+		logger.info("Initializing ThreadFix menu item: \"ThreadFix: Export Scan\"");
         setText("ThreadFix: Export Scan");
 
         addActionListener(new java.awt.event.ActionListener() {
             @Override
             public void actionPerformed(java.awt.event.ActionEvent e) {
 
-                boolean configured = ConfigurationDialogs.show(view);
+                boolean configured = ConfigurationDialogs.show(view, ConfigurationDialogs.DialogMode.THREADFIX_APPLICATION);
                 
                 if (configured) {
 	

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/LocalEndpointsAction.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/LocalEndpointsAction.java
@@ -53,7 +53,6 @@ public class LocalEndpointsAction extends EndpointsAction {
 
     @Override
     protected String getNoEndpointsMessage() {
-        // TODO: should this message be more dynamic based on what inputs were given?
         return "Failed to retrieve endpoints from the source. Check your inputs.";
     }
 
@@ -76,7 +75,6 @@ public class LocalEndpointsAction extends EndpointsAction {
     protected Endpoint.Info[] getEndpoints() {
         getLogger().info("Got source information, about to generate endpoints.");
 
-        // TODO: endpointDatabase should be generated based on source info in properties, could be a directory name or a repo URL
         EndpointDatabase endpointDatabase = EndpointDatabaseFactory.getDatabase(ZapPropertiesManager.INSTANCE.getSourceFolder());
 
         Endpoint.Info[] endpoints = null;

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/LocalEndpointsAction.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/LocalEndpointsAction.java
@@ -77,7 +77,7 @@ public class LocalEndpointsAction extends EndpointsAction {
         getLogger().info("Got source information, about to generate endpoints.");
 
         // TODO: endpointDatabase should be generated based on source info in properties, could be a directory name or a repo URL
-        EndpointDatabase endpointDatabase = EndpointDatabaseFactory.getDatabase(ZapPropertiesManager.INSTANCE.getRepositoryFolder());
+        EndpointDatabase endpointDatabase = EndpointDatabaseFactory.getDatabase(ZapPropertiesManager.INSTANCE.getSourceFolder());
 
         Endpoint.Info[] endpoints = null;
         if (endpointDatabase != null) {

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/LocalEndpointsAction.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/LocalEndpointsAction.java
@@ -1,0 +1,94 @@
+////////////////////////////////////////////////////////////////////////
+//
+//     Copyright (c) 2009-2015 Denim Group, Ltd.
+//
+//     The contents of this file are subject to the Mozilla Public License
+//     Version 2.0 (the "License"); you may not use this file except in
+//     compliance with the License. You may obtain a copy of the License at
+//     http://www.mozilla.org/MPL/
+//
+//     Software distributed under the License is distributed on an "AS IS"
+//     basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+//     License for the specific language governing rights and limitations
+//     under the License.
+//
+//     The Original Code is ThreadFix.
+//
+//     The Initial Developer of the Original Code is Denim Group, Ltd.
+//     Portions created by Denim Group, Ltd. are Copyright (C)
+//     Denim Group, Ltd. All Rights Reserved.
+//
+//     Contributor(s): Denim Group, Ltd.
+//
+////////////////////////////////////////////////////////////////////////
+
+package com.denimgroup.threadfix.plugin.zap.action;
+
+import com.denimgroup.threadfix.data.interfaces.Endpoint;
+import com.denimgroup.threadfix.framework.engine.full.EndpointDatabase;
+import com.denimgroup.threadfix.framework.engine.full.EndpointDatabaseFactory;
+import com.denimgroup.threadfix.plugin.zap.dialog.ConfigurationDialogs;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.extension.ViewDelegate;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.threadfix.ZapPropertiesManager;
+
+import java.util.List;
+
+public class LocalEndpointsAction extends EndpointsAction {
+
+    // TODO: generate a new serialVersionUID
+	private static final long serialVersionUID = 0;
+
+	private static final Logger LOGGER = Logger.getLogger(LocalEndpointsAction.class);
+
+    public LocalEndpointsAction(final ViewDelegate view, final Model model) {
+        super(view, model);
+    }
+
+    @Override
+    protected String getMenuItemText() {
+        return "ThreadFix: Import Endpoints From Source";
+    }
+
+    @Override
+    protected String getNoEndpointsMessage() {
+        // TODO: should this message be more dynamic based on what inputs were given?
+        return "Failed to retrieve endpoints from the source. Check your inputs.";
+    }
+
+    @Override
+    protected String getCompletedMessage() {
+        return "The endpoints were successfully generated from source.";
+    }
+
+    @Override
+    protected ConfigurationDialogs.DialogMode getDialogMode() {
+        return ConfigurationDialogs.DialogMode.SOURCE;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOGGER;
+    }
+
+    @Override
+    protected Endpoint.Info[] getEndpoints() {
+        getLogger().info("Got source information, about to generate endpoints.");
+
+        // TODO: endpointDatabase should be generated based on source info in properties, could be a directory name or a repo URL
+        EndpointDatabase endpointDatabase = EndpointDatabaseFactory.getDatabase(ZapPropertiesManager.INSTANCE.getRepositoryFolder());
+
+        Endpoint.Info[] endpoints = null;
+        if (endpointDatabase != null) {
+            List<Endpoint> endpointList = endpointDatabase.generateEndpoints();
+            endpoints = new Endpoint.Info[endpointList.size()];
+            int i = 0;
+            for (Endpoint endpoint : endpointList) {
+                endpoints[i++] = Endpoint.Info.fromEndpoint(endpoint);
+            }
+        }
+
+        return endpoints;
+    }
+}

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/LocalEndpointsAction.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/LocalEndpointsAction.java
@@ -37,8 +37,7 @@ import java.util.List;
 
 public class LocalEndpointsAction extends EndpointsAction {
 
-    // TODO: generate a new serialVersionUID
-	private static final long serialVersionUID = 0;
+	private static final long serialVersionUID = 1L;
 
 	private static final Logger LOGGER = Logger.getLogger(LocalEndpointsAction.class);
 

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/RemoteEndpointsAction.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/RemoteEndpointsAction.java
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////
+//
+//     Copyright (c) 2009-2015 Denim Group, Ltd.
+//
+//     The contents of this file are subject to the Mozilla Public License
+//     Version 2.0 (the "License"); you may not use this file except in
+//     compliance with the License. You may obtain a copy of the License at
+//     http://www.mozilla.org/MPL/
+//
+//     Software distributed under the License is distributed on an "AS IS"
+//     basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+//     License for the specific language governing rights and limitations
+//     under the License.
+//
+//     The Original Code is ThreadFix.
+//
+//     The Initial Developer of the Original Code is Denim Group, Ltd.
+//     Portions created by Denim Group, Ltd. are Copyright (C)
+//     Denim Group, Ltd. All Rights Reserved.
+//
+//     Contributor(s): Denim Group, Ltd.
+//
+////////////////////////////////////////////////////////////////////////
+
+package com.denimgroup.threadfix.plugin.zap.action;
+
+import com.denimgroup.threadfix.data.interfaces.Endpoint;
+import com.denimgroup.threadfix.plugin.zap.dialog.ConfigurationDialogs;
+import com.denimgroup.threadfix.remote.PluginClient;
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.extension.ViewDelegate;
+import org.parosproxy.paros.model.Model;
+import org.zaproxy.zap.extension.threadfix.ZapPropertiesManager;
+
+public class RemoteEndpointsAction extends EndpointsAction {
+
+    // TODO: generate a new serialVersionUID
+    private static final long serialVersionUID = 0;
+
+	private static final Logger LOGGER = Logger.getLogger(RemoteEndpointsAction.class);
+
+    public RemoteEndpointsAction(final ViewDelegate view, final Model model) {
+        super(view, model);
+    }
+
+    @Override
+    protected String getMenuItemText() {
+        return "ThreadFix: Import Endpoints From ThreadFix";
+    }
+
+    @Override
+    protected String getNoEndpointsMessage() {
+        return "Failed to retrieve endpoints from ThreadFix. Check your key and url.";
+    }
+
+    @Override
+    protected String getCompletedMessage() {
+        return "The endpoints were successfully imported from ThreadFix.";
+    }
+
+    @Override
+    protected ConfigurationDialogs.DialogMode getDialogMode() {
+        return ConfigurationDialogs.DialogMode.THREADFIX_APPLICATION;
+    }
+
+    @Override
+    protected Logger getLogger() {
+        return LOGGER;
+    }
+
+    @Override
+    protected Endpoint.Info[] getEndpoints() {
+        getLogger().info("Got application id, about to generate XML and use REST call.");
+
+        Endpoint.Info[] endpoints = new PluginClient(ZapPropertiesManager.INSTANCE)
+                .getEndpoints(ZapPropertiesManager.INSTANCE.getAppId());
+
+        return endpoints;
+    }
+}

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/RemoteEndpointsAction.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/action/RemoteEndpointsAction.java
@@ -34,8 +34,7 @@ import org.zaproxy.zap.extension.threadfix.ZapPropertiesManager;
 
 public class RemoteEndpointsAction extends EndpointsAction {
 
-    // TODO: generate a new serialVersionUID
-    private static final long serialVersionUID = 0;
+    private static final long serialVersionUID = 1L;
 
 	private static final Logger LOGGER = Logger.getLogger(RemoteEndpointsAction.class);
 

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/dialog/ConfigurationDialogs.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/dialog/ConfigurationDialogs.java
@@ -28,22 +28,36 @@ import org.apache.log4j.Logger;
 import org.parosproxy.paros.extension.ViewDelegate;
 
 public class ConfigurationDialogs {
+
+    public static enum DialogMode {
+        THREADFIX_APPLICATION, SOURCE;
+    }
 	
 	private static final Logger logger = Logger.getLogger(ConfigurationDialogs.class);
 
 	private ConfigurationDialogs() {}
 	
-	public static boolean show(ViewDelegate view) {
-		logger.info("About to show dialog.");
+	public static boolean show(ViewDelegate view, DialogMode mode) {
+        if (mode == DialogMode.THREADFIX_APPLICATION) {
+            logger.info("About to show dialog.");
 
-        boolean shouldContinue = ParametersDialog.show(view);
-        
-        if (shouldContinue) {
-            logger.info("Got url and key settings. About to show Application selection.");
-	
-            shouldContinue = ApplicationDialog.show(view);
+            boolean shouldContinue = ParametersDialog.show(view);
+
+            if (shouldContinue) {
+                logger.info("Got url and key settings. About to show Application selection.");
+
+                shouldContinue = ApplicationDialog.show(view);
+            }
+
+            return shouldContinue;
+        } else if (mode == DialogMode.SOURCE) {
+            logger.info("About to show dialog.");
+
+            boolean shouldContinue = SourceDialog.show(view);
+
+            return shouldContinue;
+        } else {
+            return false;
         }
-        
-        return shouldContinue;
 	}
 }

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/dialog/SourceDialog.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/dialog/SourceDialog.java
@@ -1,0 +1,128 @@
+////////////////////////////////////////////////////////////////////////
+//
+//     Copyright (c) 2009-2015 Denim Group, Ltd.
+//
+//     The contents of this file are subject to the Mozilla Public License
+//     Version 2.0 (the "License"); you may not use this file except in
+//     compliance with the License. You may obtain a copy of the License at
+//     http://www.mozilla.org/MPL/
+//
+//     Software distributed under the License is distributed on an "AS IS"
+//     basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+//     License for the specific language governing rights and limitations
+//     under the License.
+//
+//     The Original Code is ThreadFix.
+//
+//     The Initial Developer of the Original Code is Denim Group, Ltd.
+//     Portions created by Denim Group, Ltd. are Copyright (C)
+//     Denim Group, Ltd. All Rights Reserved.
+//
+//     Contributor(s): Denim Group, Ltd.
+//
+////////////////////////////////////////////////////////////////////////
+
+package com.denimgroup.threadfix.plugin.zap.dialog;
+
+import org.apache.log4j.Logger;
+import org.parosproxy.paros.extension.ViewDelegate;
+import org.zaproxy.zap.extension.threadfix.ZapPropertiesManager;
+
+import javax.swing.*;
+import java.awt.*;
+
+public class SourceDialog {
+
+    private static final String
+            PASSWORD_PLACEHOLDER = "PASSWORD";
+
+    private static final Logger logger = Logger.getLogger(SourceDialog.class);
+
+    public static boolean show(ViewDelegate view) {
+        logger.info("Attempting to show dialog.");
+        JTextField repositoryUrlField = new JTextField(40);
+        repositoryUrlField.setText(ZapPropertiesManager.INSTANCE.getRepositoryUrl());
+        JTextField repositoryBranchField = new JTextField(40);
+        repositoryBranchField.setText(ZapPropertiesManager.INSTANCE.getRepositoryBranch());
+        JTextField repositoryUserNameField = new JTextField(40);
+        repositoryUserNameField.setText(ZapPropertiesManager.INSTANCE.getRepositoryUserName());
+        JPasswordField repositoryPasswordField = new JPasswordField(40);
+        char[] repositoryPassword = ZapPropertiesManager.INSTANCE.getRepositoryPassword();
+        if (repositoryPassword == null) {
+            repositoryPasswordField.setText("");
+        } else {
+            repositoryPasswordField.setText(PASSWORD_PLACEHOLDER);
+        }
+        JTextField repositoryFolderField = new JTextField(40);
+        repositoryFolderField.setText(ZapPropertiesManager.INSTANCE.getRepositoryFolder());
+
+        GridBagLayout experimentLayout = new GridBagLayout();
+        GridBagConstraints labelConstraints = new GridBagConstraints();
+        labelConstraints.gridwidth = 1;
+        labelConstraints.gridx = 0;
+        labelConstraints.gridy = 0;
+        labelConstraints.fill = GridBagConstraints.HORIZONTAL;
+        GridBagConstraints textBoxConstraints = new GridBagConstraints();
+        textBoxConstraints.gridwidth = 4;
+        textBoxConstraints.gridx = 1;
+        textBoxConstraints.gridy = 0;
+        textBoxConstraints.fill = GridBagConstraints.HORIZONTAL;
+
+        JPanel myPanel = new JPanel();
+        myPanel.setLayout(experimentLayout);
+
+        myPanel.add(new JLabel("Source Code URL"), labelConstraints);
+        myPanel.add(repositoryUrlField, textBoxConstraints);
+
+        labelConstraints.gridy++;
+        textBoxConstraints.gridy++;
+
+        myPanel.add(new JLabel("Source Code Revision"), labelConstraints);
+        myPanel.add(repositoryBranchField, textBoxConstraints);
+
+        labelConstraints.gridy++;
+        textBoxConstraints.gridy++;
+
+        myPanel.add(new JLabel("Source Code User Name"), labelConstraints);
+        myPanel.add(repositoryUserNameField, textBoxConstraints);
+
+        labelConstraints.gridy++;
+        textBoxConstraints.gridy++;
+
+        myPanel.add(new JLabel("Source Code Password"), labelConstraints);
+        myPanel.add(repositoryPasswordField, textBoxConstraints);
+
+        labelConstraints.gridy++;
+        textBoxConstraints.gridy++;
+
+        myPanel.add(new JLabel("Source Code Folder"), labelConstraints);
+        myPanel.add(repositoryFolderField, textBoxConstraints);
+
+        String attempt = SourceDialog.class.getProtectionDomain().getCodeSource().getLocation().getFile() + "/dg-icon.png";
+
+        logger.info("Trying " + attempt);
+
+        ImageIcon icon = new ImageIcon(attempt);
+
+        int result = JOptionPane.showConfirmDialog(view.getMainFrame(),
+                myPanel,
+                "Please enter the appropriate information for accessing the source code",
+                JOptionPane.OK_CANCEL_OPTION,
+                JOptionPane.INFORMATION_MESSAGE,
+                icon);
+        if (result == JOptionPane.OK_OPTION) {
+            ZapPropertiesManager.setRepositoryInformation(repositoryUrlField.getText(), repositoryBranchField.getText(), repositoryUserNameField.getText(), repositoryFolderField.getText());
+            repositoryPassword = repositoryPasswordField.getPassword();
+            logger.info("Password Field: " + repositoryPassword);
+            if ((repositoryPassword.length > 0) && !(repositoryPassword.equals(PASSWORD_PLACEHOLDER.toCharArray()))) {
+                ZapPropertiesManager.setRepositoryPassword(repositoryPassword);
+            }
+            logger.info("Got properties and saved.");
+            return true;
+        } else {
+            logger.info("Cancel pressed.");
+            return false;
+        }
+    }
+
+}

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/dialog/SourceDialog.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/dialog/SourceDialog.java
@@ -35,10 +35,29 @@ public class SourceDialog {
 
     private static final Logger logger = Logger.getLogger(SourceDialog.class);
 
-    public static boolean show(ViewDelegate view) {
+    public static boolean show(final ViewDelegate view) {
         logger.info("Attempting to show dialog.");
-        JTextField sourceFolderField = new JTextField(40);
+        final JLabel sourceFolderLabel = new JLabel("Source Code Folder");
+        final JTextField sourceFolderField = new JTextField(40);
         sourceFolderField.setText(ZapPropertiesManager.INSTANCE.getSourceFolder());
+        final JButton browseButton = new JButton("Browse");
+        browseButton.addActionListener(new java.awt.event.ActionListener() {
+            @Override
+            public void actionPerformed(java.awt.event.ActionEvent e) {
+                JFileChooser chooser = new JFileChooser();
+                String currentDirectory = sourceFolderField.getText();
+                if ((currentDirectory == null) || (currentDirectory.trim().equals(""))) {
+                    currentDirectory = System.getProperty("user.home");
+                }
+                chooser.setCurrentDirectory(new java.io.File(currentDirectory));
+                chooser.setDialogTitle("Select A Source Code Folder");
+                chooser.setFileSelectionMode(JFileChooser.DIRECTORIES_ONLY);
+                chooser.setAcceptAllFileFilterUsed(false);
+                if (chooser.showOpenDialog(view.getMainFrame()) == JFileChooser.APPROVE_OPTION) {
+                    sourceFolderField.setText(chooser.getSelectedFile().getAbsolutePath());
+                }
+            }
+        });
 
         GridBagLayout experimentLayout = new GridBagLayout();
         GridBagConstraints labelConstraints = new GridBagConstraints();
@@ -51,11 +70,17 @@ public class SourceDialog {
         textBoxConstraints.gridx = 1;
         textBoxConstraints.gridy = 0;
         textBoxConstraints.fill = GridBagConstraints.HORIZONTAL;
+        GridBagConstraints browseButtonConstraints = new GridBagConstraints();
+        browseButtonConstraints.gridwidth = 1;
+        browseButtonConstraints.gridx = 5;
+        browseButtonConstraints.gridy = 0;
+        browseButtonConstraints.fill = GridBagConstraints.HORIZONTAL;
 
         JPanel myPanel = new JPanel();
         myPanel.setLayout(experimentLayout);
-        myPanel.add(new JLabel("Source Code Folder"), labelConstraints);
+        myPanel.add(sourceFolderLabel, labelConstraints);
         myPanel.add(sourceFolderField, textBoxConstraints);
+        myPanel.add(browseButton, browseButtonConstraints);
 
         String attempt = SourceDialog.class.getProtectionDomain().getCodeSource().getLocation().getFile() + "/dg-icon.png";
 

--- a/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/dialog/SourceDialog.java
+++ b/threadfix-scanner-plugin/zaproxy/src/com/denimgroup/threadfix/plugin/zap/dialog/SourceDialog.java
@@ -33,28 +33,12 @@ import java.awt.*;
 
 public class SourceDialog {
 
-    private static final String
-            PASSWORD_PLACEHOLDER = "PASSWORD";
-
     private static final Logger logger = Logger.getLogger(SourceDialog.class);
 
     public static boolean show(ViewDelegate view) {
         logger.info("Attempting to show dialog.");
-        JTextField repositoryUrlField = new JTextField(40);
-        repositoryUrlField.setText(ZapPropertiesManager.INSTANCE.getRepositoryUrl());
-        JTextField repositoryBranchField = new JTextField(40);
-        repositoryBranchField.setText(ZapPropertiesManager.INSTANCE.getRepositoryBranch());
-        JTextField repositoryUserNameField = new JTextField(40);
-        repositoryUserNameField.setText(ZapPropertiesManager.INSTANCE.getRepositoryUserName());
-        JPasswordField repositoryPasswordField = new JPasswordField(40);
-        char[] repositoryPassword = ZapPropertiesManager.INSTANCE.getRepositoryPassword();
-        if (repositoryPassword == null) {
-            repositoryPasswordField.setText("");
-        } else {
-            repositoryPasswordField.setText(PASSWORD_PLACEHOLDER);
-        }
-        JTextField repositoryFolderField = new JTextField(40);
-        repositoryFolderField.setText(ZapPropertiesManager.INSTANCE.getRepositoryFolder());
+        JTextField sourceFolderField = new JTextField(40);
+        sourceFolderField.setText(ZapPropertiesManager.INSTANCE.getSourceFolder());
 
         GridBagLayout experimentLayout = new GridBagLayout();
         GridBagConstraints labelConstraints = new GridBagConstraints();
@@ -70,33 +54,8 @@ public class SourceDialog {
 
         JPanel myPanel = new JPanel();
         myPanel.setLayout(experimentLayout);
-
-        myPanel.add(new JLabel("Source Code URL"), labelConstraints);
-        myPanel.add(repositoryUrlField, textBoxConstraints);
-
-        labelConstraints.gridy++;
-        textBoxConstraints.gridy++;
-
-        myPanel.add(new JLabel("Source Code Revision"), labelConstraints);
-        myPanel.add(repositoryBranchField, textBoxConstraints);
-
-        labelConstraints.gridy++;
-        textBoxConstraints.gridy++;
-
-        myPanel.add(new JLabel("Source Code User Name"), labelConstraints);
-        myPanel.add(repositoryUserNameField, textBoxConstraints);
-
-        labelConstraints.gridy++;
-        textBoxConstraints.gridy++;
-
-        myPanel.add(new JLabel("Source Code Password"), labelConstraints);
-        myPanel.add(repositoryPasswordField, textBoxConstraints);
-
-        labelConstraints.gridy++;
-        textBoxConstraints.gridy++;
-
         myPanel.add(new JLabel("Source Code Folder"), labelConstraints);
-        myPanel.add(repositoryFolderField, textBoxConstraints);
+        myPanel.add(sourceFolderField, textBoxConstraints);
 
         String attempt = SourceDialog.class.getProtectionDomain().getCodeSource().getLocation().getFile() + "/dg-icon.png";
 
@@ -106,17 +65,12 @@ public class SourceDialog {
 
         int result = JOptionPane.showConfirmDialog(view.getMainFrame(),
                 myPanel,
-                "Please enter the appropriate information for accessing the source code",
+                "Please enter the location of the source code",
                 JOptionPane.OK_CANCEL_OPTION,
                 JOptionPane.INFORMATION_MESSAGE,
                 icon);
         if (result == JOptionPane.OK_OPTION) {
-            ZapPropertiesManager.setRepositoryInformation(repositoryUrlField.getText(), repositoryBranchField.getText(), repositoryUserNameField.getText(), repositoryFolderField.getText());
-            repositoryPassword = repositoryPasswordField.getPassword();
-            logger.info("Password Field: " + repositoryPassword);
-            if ((repositoryPassword.length > 0) && !(repositoryPassword.equals(PASSWORD_PLACEHOLDER.toCharArray()))) {
-                ZapPropertiesManager.setRepositoryPassword(repositoryPassword);
-            }
+            ZapPropertiesManager.setSourceFolder(sourceFolderField.getText());
             logger.info("Got properties and saved.");
             return true;
         } else {

--- a/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ThreadFixExtension.java
+++ b/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ThreadFixExtension.java
@@ -24,8 +24,9 @@
 
 package org.zaproxy.zap.extension.threadfix;
 
-import com.denimgroup.threadfix.plugin.zap.action.EndpointsAction;
 import com.denimgroup.threadfix.plugin.zap.action.ImportAction;
+import com.denimgroup.threadfix.plugin.zap.action.LocalEndpointsAction;
+import com.denimgroup.threadfix.plugin.zap.action.RemoteEndpointsAction;
 import org.apache.log4j.Logger;
 import org.parosproxy.paros.extension.ExtensionAdaptor;
 import org.parosproxy.paros.extension.ExtensionHook;
@@ -37,7 +38,7 @@ import java.util.ResourceBundle;
 
 public class ThreadFixExtension extends ExtensionAdaptor {
 
-    private JMenuItem importAction = null, endpointsAction = null;
+    private JMenuItem importAction = null, remoteEndpointsAction = null, localEndpointsAction = null;
     private ResourceBundle messages = null;
 
     private static final Logger logger = Logger.getLogger(ThreadFixExtension.class);
@@ -89,7 +90,8 @@ public class ThreadFixExtension extends ExtensionAdaptor {
             // Register our top menu item, as long as we're not running as a daemon
             // Use one of the other methods to add to a different menu list
             extensionHook.getHookMenu().addToolsMenuItem(getImportAction());
-            extensionHook.getHookMenu().addToolsMenuItem(getEndpointsAction());
+            extensionHook.getHookMenu().addToolsMenuItem(getRemoteEndpointsAction());
+            extensionHook.getHookMenu().addToolsMenuItem(getLocalEndpointsAction());
         }
 
     }
@@ -102,12 +104,20 @@ public class ThreadFixExtension extends ExtensionAdaptor {
         return importAction;
     }
 
-    private JMenuItem getEndpointsAction() {
+    private JMenuItem getRemoteEndpointsAction() {
        logger.info("Getting menu");
-        if (endpointsAction == null) {
-            endpointsAction = new EndpointsAction(getView(), getModel());
+        if (remoteEndpointsAction == null) {
+            remoteEndpointsAction = new RemoteEndpointsAction(getView(), getModel());
         }
-        return endpointsAction;
+        return remoteEndpointsAction;
+    }
+
+    private JMenuItem getLocalEndpointsAction() {
+        logger.info("Getting menu");
+        if (localEndpointsAction == null) {
+            localEndpointsAction = new LocalEndpointsAction(getView(), getModel());
+        }
+        return localEndpointsAction;
     }
 
     public String getMessageString(String key) {

--- a/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapPropertiesManager.java
+++ b/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapPropertiesManager.java
@@ -33,6 +33,8 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Properties;
 
+import org.parosproxy.paros.Constant;
+
 /**
  * Created by mac on 9/23/13.
  */
@@ -101,7 +103,7 @@ public class ZapPropertiesManager extends PropertiesManager {
     private static Properties getProperties() {
         Properties properties = new Properties();
 
-        File file = new File(FILE_NAME);
+        File file = new File(Constant.getZapHome(), FILE_NAME);
 
         logger.info("Properties file is at " + file.getAbsolutePath());
 
@@ -129,7 +131,7 @@ public class ZapPropertiesManager extends PropertiesManager {
     }
 
     private static void saveProperties(Properties properties) {
-        try (FileWriter writer = new FileWriter(new File(FILE_NAME))) {
+        try (FileWriter writer = new FileWriter(new File(Constant.getZapHome(), FILE_NAME))) {
             properties.store(writer, SAVE_MESSAGE);
         } catch (IOException e) {
             logger.warn(e.getMessage(), e);

--- a/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapPropertiesManager.java
+++ b/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapPropertiesManager.java
@@ -49,11 +49,7 @@ public class ZapPropertiesManager extends PropertiesManager {
             API_KEY_KEY = "key",
             URL_KEY = "url",
             APP_ID_KEY = "application-id",
-            REPOSITORY_URL_KEY = "repository-url",
-            REPOSITORY_BRANCH_KEY = "repository-branch",
-            REPOSITORY_USER_NAME_KEY = "repository-user-name",
-            REPOSITORY_PASSWORD_KEY = "repository-password",
-            REPOSITORY_FOLDER_KEY = "repository-folder",
+            SOURCE_FOLDER_KEY = "source-folder",
             SAVE_MESSAGE = "Saving ZAP properties.";
 
     @Override
@@ -77,38 +73,10 @@ public class ZapPropertiesManager extends PropertiesManager {
         return url;
     }
 
-    public String getRepositoryUrl() {
-        String repositoryUrl = getProperties().getProperty(REPOSITORY_URL_KEY);
-        logger.info("returning source code url " + repositoryUrl);
-        return repositoryUrl;
-    }
-
-    public String getRepositoryBranch() {
-        String repositoryBranch = getProperties().getProperty(REPOSITORY_BRANCH_KEY);
-        logger.info("returning source code branch " + repositoryBranch);
-        return repositoryBranch;
-    }
-
-    public String getRepositoryUserName() {
-        String repositoryUserName = getProperties().getProperty(REPOSITORY_USER_NAME_KEY);
-        logger.info("returning source code user name " + repositoryUserName);
-        return repositoryUserName;
-    }
-
-    public char[] getRepositoryPassword() {
-        String repositoryPassword = getProperties().getProperty(REPOSITORY_PASSWORD_KEY);
-        logger.info("returning source code password");
-        if (repositoryPassword != null) {
-            return repositoryPassword.toCharArray();
-        } else {
-            return null;
-        }
-    }
-
-    public String getRepositoryFolder() {
-        String repositoryFolder = getProperties().getProperty(REPOSITORY_FOLDER_KEY);
-        logger.info("returning source code folder " + repositoryFolder);
-        return repositoryFolder;
+    public String getSourceFolder() {
+        String sourceFolder = getProperties().getProperty(SOURCE_FOLDER_KEY);
+        logger.info("returning source code folder " + sourceFolder);
+        return sourceFolder;
     }
 
     public static void setKeyAndUrl(String newKey, String newUrl) {
@@ -124,18 +92,9 @@ public class ZapPropertiesManager extends PropertiesManager {
         saveProperties(properties);
     }
 
-    public static void setRepositoryInformation(String repositoryUrl, String repositoryBranch, String repositoryUserName, String repositoryFolder) {
+    public static void setSourceFolder(String sourceFolder) {
         Properties properties = getProperties();
-        properties.setProperty(REPOSITORY_URL_KEY, repositoryUrl);
-        properties.setProperty(REPOSITORY_BRANCH_KEY, repositoryBranch);
-        properties.setProperty(REPOSITORY_USER_NAME_KEY, repositoryUserName);
-        properties.setProperty(REPOSITORY_FOLDER_KEY, repositoryFolder);
-        saveProperties(properties);
-    }
-
-    public static void setRepositoryPassword(char[] repositoryPassword) {
-        Properties properties = getProperties();
-        properties.setProperty(REPOSITORY_PASSWORD_KEY, String.valueOf(repositoryPassword));
+        properties.setProperty(SOURCE_FOLDER_KEY, sourceFolder);
         saveProperties(properties);
     }
 

--- a/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapPropertiesManager.java
+++ b/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapPropertiesManager.java
@@ -49,6 +49,11 @@ public class ZapPropertiesManager extends PropertiesManager {
             API_KEY_KEY = "key",
             URL_KEY = "url",
             APP_ID_KEY = "application-id",
+            REPOSITORY_URL_KEY = "repository-url",
+            REPOSITORY_BRANCH_KEY = "repository-branch",
+            REPOSITORY_USER_NAME_KEY = "repository-user-name",
+            REPOSITORY_PASSWORD_KEY = "repository-password",
+            REPOSITORY_FOLDER_KEY = "repository-folder",
             SAVE_MESSAGE = "Saving ZAP properties.";
 
     @Override
@@ -72,6 +77,40 @@ public class ZapPropertiesManager extends PropertiesManager {
         return url;
     }
 
+    public String getRepositoryUrl() {
+        String repositoryUrl = getProperties().getProperty(REPOSITORY_URL_KEY);
+        logger.info("returning source code url " + repositoryUrl);
+        return repositoryUrl;
+    }
+
+    public String getRepositoryBranch() {
+        String repositoryBranch = getProperties().getProperty(REPOSITORY_BRANCH_KEY);
+        logger.info("returning source code branch " + repositoryBranch);
+        return repositoryBranch;
+    }
+
+    public String getRepositoryUserName() {
+        String repositoryUserName = getProperties().getProperty(REPOSITORY_USER_NAME_KEY);
+        logger.info("returning source code user name " + repositoryUserName);
+        return repositoryUserName;
+    }
+
+    public char[] getRepositoryPassword() {
+        String repositoryPassword = getProperties().getProperty(REPOSITORY_PASSWORD_KEY);
+        logger.info("returning source code password");
+        if (repositoryPassword != null) {
+            return repositoryPassword.toCharArray();
+        } else {
+            return null;
+        }
+    }
+
+    public String getRepositoryFolder() {
+        String repositoryFolder = getProperties().getProperty(REPOSITORY_FOLDER_KEY);
+        logger.info("returning source code folder " + repositoryFolder);
+        return repositoryFolder;
+    }
+
     public static void setKeyAndUrl(String newKey, String newUrl) {
         Properties properties = getProperties();
         properties.setProperty(API_KEY_KEY, newKey);
@@ -82,6 +121,21 @@ public class ZapPropertiesManager extends PropertiesManager {
     public static void setAppId(String appId) {
         Properties properties = getProperties();
         properties.setProperty(APP_ID_KEY, appId);
+        saveProperties(properties);
+    }
+
+    public static void setRepositoryInformation(String repositoryUrl, String repositoryBranch, String repositoryUserName, String repositoryFolder) {
+        Properties properties = getProperties();
+        properties.setProperty(REPOSITORY_URL_KEY, repositoryUrl);
+        properties.setProperty(REPOSITORY_BRANCH_KEY, repositoryBranch);
+        properties.setProperty(REPOSITORY_USER_NAME_KEY, repositoryUserName);
+        properties.setProperty(REPOSITORY_FOLDER_KEY, repositoryFolder);
+        saveProperties(properties);
+    }
+
+    public static void setRepositoryPassword(char[] repositoryPassword) {
+        Properties properties = getProperties();
+        properties.setProperty(REPOSITORY_PASSWORD_KEY, String.valueOf(repositoryPassword));
         saveProperties(properties);
     }
 


### PR DESCRIPTION
Added HAM support to the Threadfix ZAP plugin so that endpoints can be generated from local code.
Updated the plugin's pom.xml to properly generate a ZAP plugin file.
Moved the threadfix.properties file to the ZAP Home folder.