### PR TITLE
Fixed the fully qualified path for ThreadFixExtension in ZapAddOn.xml.

### DIFF
--- a/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapAddOn.xml
+++ b/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapAddOn.xml
@@ -7,7 +7,7 @@
     <changes>First Version</changes>
     <dependson/>
     <extensions>
-        <extension>org.zaproxy.zap.extension.ThreadFixExtension</extension>
+        <extension>org.zaproxy.zap.extension.threadfix.ThreadFixExtension</extension>
     </extensions>
     <ascanrules/>
     <pscanrules/>


### PR DESCRIPTION
ZAP 2.3.1 loaded the addon despite this mistake. The latest ZAP weekly build (2.4) will not load the addon with the incorrect extension name. 