### PR TITLE
Dgtf 991 add tools download page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,12 @@
 
     <modules>
         <module>threadfix-entities</module>
+        <module>csv2ssvl</module>
         <module>threadfix-data-access</module>
         <module>threadfix-cli</module>
         <module>threadfix-ham</module>
         <module>threadfix-importers</module>
         <module>threadfix-service-interfaces</module>
-        <module>threadfix-main</module>
         <module>threadfix-offline</module>
         <module>threadfix-scanner-plugin/zaproxy</module>
         <module>threadfix-scanner-plugin/burp</module>
@@ -30,6 +30,7 @@
         <module>threadfix-cli-endpoints</module>
         <module>threadfix-cli-importers</module>
         <module>threadfix-data-migration</module>
+        <module>threadfix-main</module>
     </modules>
 
     <licenses>

--- a/threadfix-main/pom.xml
+++ b/threadfix-main/pom.xml
@@ -136,6 +136,33 @@
                             </tasks>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>Copy Downloads</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <copy file="${project.build.directory}/../../threadfix-cli/target/threadfix-cli-${project.version}-jar-with-dependencies.jar"
+                                      tofile="target/classes/downloads/tfcli.jar" />
+                                <copy file="${project.build.directory}/../../threadfix-cli-importers/target/threadfix-cli-importers-${project.version}.jar"
+                                      tofile="target/classes/downloads/threadfix-cli-importers.jar" />
+                                <copy file="${project.build.directory}/../../threadfix-cli-endpoints/target/threadfix-endpoint-cli-${project.version}-jar-with-dependencies.jar"
+                                      tofile="target/classes/downloads/endpoints.jar" />
+                                <copy file="${project.build.directory}/../../threadfix-data-migration/target/threadfix-data-migration-${project.version}.jar"
+                                      tofile="target/classes/downloads/threadfix-data-migration.jar" />
+                                <copy file="${project.build.directory}/../../threadfix-scanner-plugin/burp/target/threadfix-release-2-jar-with-dependencies.jar"
+                                      tofile="target/classes/downloads/threadfix-release-2-burp.jar" />
+                                <copy file="${project.build.directory}/../../threadfix-scanner-plugin/zaproxy/target/threadfix-release-2.zap"
+                                      tofile="target/classes/downloads/threadfix-release-2.zap" />
+                                <copy file="${project.build.directory}/../../threadfix-sonar-plugin/target/sonar-threadfix-plugin-${project.version}.jar"
+                                      tofile="target/classes/downloads/sonar-threadfix-plugin.jar" />
+                                <copy file="${project.build.directory}/../../csv2ssvl/target/CSV2SSVL-1.0-SNAPSHOT-jar-with-dependencies.jar"
+                                      tofile="target/classes/downloads/csv2ssvl.jar" />
+                            </tasks>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>

--- a/threadfix-main/src/main/java/com/denimgroup/threadfix/webapp/controller/ToolsDownloadController.java
+++ b/threadfix-main/src/main/java/com/denimgroup/threadfix/webapp/controller/ToolsDownloadController.java
@@ -42,7 +42,7 @@ public class ToolsDownloadController {
 
 	private final SanitizedLogger log = new SanitizedLogger(ToolsDownloadController.class);
     private final static String CSV2SSVL_JAR = "CSV2SSVL-1.0-SNAPSHOT-jar-with-dependencies.jar";
-    private final static String TF_CLI_JAR = "threadfix-cli-2.0-jar-with-dependencies.jar";
+    private final static String TF_CLI_JAR = "threadfix-cli-2.2-jar-with-dependencies.jar";
     private final static String TF_SCAN_IMPORTER_JAR = "threadfix-cli-importers-2.2-SNAPSHOT.jar";
     private final static String TF_HAM_CLI_JAR = "threadfix-ham-2.2-SNAPSHOT.jar";
     private final static String TF_DATA_MIGRATION_JAR = "threadfix-data-migration-2.2-SNAPSHOT.jar";
@@ -61,9 +61,8 @@ public class ToolsDownloadController {
     }
 
     @RequestMapping(value="/tfcli")
-    public String doDownloadTFcli(HttpServletRequest request, HttpServletResponse response) {
+    public void doDownloadTFcli(HttpServletRequest request, HttpServletResponse response) {
         doDownload(request, response, TF_CLI_JAR);
-        return "config/download/index";
     }
 
     @RequestMapping(value="/tfscancli")
@@ -72,15 +71,13 @@ public class ToolsDownloadController {
     }
 
     @RequestMapping(value="/tfhamcli")
-    public String doDownloadTFhamcli(HttpServletRequest request, HttpServletResponse response) {
+    public void doDownloadTFhamcli(HttpServletRequest request, HttpServletResponse response) {
         doDownload(request, response, TF_HAM_CLI_JAR);
-        return "config/download/index";
     }
 
     @RequestMapping(value="/tfdatamigration")
-    public String doDownloadTFdatamigration(HttpServletRequest request, HttpServletResponse response) {
+    public void doDownloadTFdatamigration(HttpServletRequest request, HttpServletResponse response) {
         doDownload(request, response, TF_DATA_MIGRATION_JAR);
-        return "config/download/index";
     }
 
     private void doDownload(HttpServletRequest request, HttpServletResponse response, String jarName) {

--- a/threadfix-main/src/main/java/com/denimgroup/threadfix/webapp/controller/ToolsDownloadController.java
+++ b/threadfix-main/src/main/java/com/denimgroup/threadfix/webapp/controller/ToolsDownloadController.java
@@ -32,17 +32,20 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 
 @Controller
 @RequestMapping("/configuration/download")
 public class ToolsDownloadController {
 
 	private final SanitizedLogger log = new SanitizedLogger(ToolsDownloadController.class);
+
+    private final static String JAR_DOWNLOAD_DIR = "/WEB-INF/download/";
+
     private final static String CSV2SSVL_JAR = "CSV2SSVL-1.0-SNAPSHOT-jar-with-dependencies.jar";
-    private final static String TF_CLI_JAR = "threadfix-cli-2.2-jar-with-dependencies.jar";
+    private final static String TF_CLI_JAR = "threadfix-cli-2.2-SNAPSHOT-jar-with-dependencies.jar";
     private final static String TF_SCAN_IMPORTER_JAR = "threadfix-cli-importers-2.2-SNAPSHOT.jar";
     private final static String TF_HAM_CLI_JAR = "threadfix-ham-2.2-SNAPSHOT.jar";
     private final static String TF_DATA_MIGRATION_JAR = "threadfix-data-migration-2.2-SNAPSHOT.jar";
@@ -56,59 +59,81 @@ public class ToolsDownloadController {
 	}
 
     @RequestMapping(value="/csv2ssvl")
-    public void doDownloadCsv2ssvl(HttpServletRequest request, HttpServletResponse response) {
-        doDownload(request, response, CSV2SSVL_JAR);
+    public String doDownloadCsv2ssvl(HttpServletRequest request, HttpServletResponse response) {
+        String destination = null;
+        try {
+            doDownload(request, response, CSV2SSVL_JAR);
+        } catch (Exception e) {
+            destination = "config/download/index";
+        }
+        return destination;
     }
 
     @RequestMapping(value="/tfcli")
-    public void doDownloadTFcli(HttpServletRequest request, HttpServletResponse response) {
-        doDownload(request, response, TF_CLI_JAR);
+    public String doDownloadTFcli(HttpServletRequest request, HttpServletResponse response) {
+        String destination = null;
+        try {
+            doDownload(request, response, TF_CLI_JAR);
+        } catch (Exception e) {
+            destination = "config/download/index";
+        }
+        return destination;
     }
 
     @RequestMapping(value="/tfscancli")
-    public void doDownloadTFscancli(HttpServletRequest request, HttpServletResponse response) {
-        doDownload(request, response, TF_SCAN_IMPORTER_JAR);
+    public String doDownloadTFscancli(HttpServletRequest request, HttpServletResponse response) {
+        String destination = null;
+        try {
+            doDownload(request, response, TF_SCAN_IMPORTER_JAR);
+        } catch (Exception e) {
+            destination = "config/download/index";
+        }
+        return destination;
     }
 
     @RequestMapping(value="/tfhamcli")
-    public void doDownloadTFhamcli(HttpServletRequest request, HttpServletResponse response) {
-        doDownload(request, response, TF_HAM_CLI_JAR);
+    public String doDownloadTFhamcli(HttpServletRequest request, HttpServletResponse response) {
+        String destination = null;
+        try {
+            doDownload(request, response, TF_HAM_CLI_JAR);
+        } catch (Exception e) {
+            destination = "config/download/index";
+        }
+        return destination;
     }
 
     @RequestMapping(value="/tfdatamigration")
-    public void doDownloadTFdatamigration(HttpServletRequest request, HttpServletResponse response) {
-        doDownload(request, response, TF_DATA_MIGRATION_JAR);
+    public String doDownloadTFdatamigration(HttpServletRequest request, HttpServletResponse response) {
+        String destination = null;
+        try {
+            doDownload(request, response, TF_DATA_MIGRATION_JAR);
+        } catch (Exception e) {
+            destination = "config/download/index";
+        }
+        return destination;
     }
 
-    private void doDownload(HttpServletRequest request, HttpServletResponse response, String jarName) {
+    private void doDownload(HttpServletRequest request, HttpServletResponse response, String jarName) throws IOException {
 
-        String jarResource = "/WEB-INF/download/" + jarName;
+        String jarResource = JAR_DOWNLOAD_DIR + jarName;
 
         InputStream in = request.getServletContext().getResourceAsStream(jarResource);
         if (in == null) {
             log.error("JAR File not found for download: " + jarResource);
-            return;
+            throw new FileNotFoundException("JAR File not found for download: " + jarResource);
         }
 
-        ServletOutputStream out;
+        ServletOutputStream out = response.getOutputStream();
+        int jarSize = request.getServletContext().getResource(jarResource).openConnection().getContentLength();
 
-        try {
-            out = response.getOutputStream();
-            int jarSize = request.getServletContext().getResource(jarResource).openConnection().getContentLength();
+        response.setContentType("application/java-archive");
+        response.setContentLength(jarSize);
+        response.addHeader("Content-Disposition", "attachment; filename=\"" + jarName + "\"");
 
-            response.setContentType("application/java-archive");
-            response.setContentLength(jarSize);
-
-            response.addHeader("Content-Disposition", "attachment; filename=\"" + jarName + "\"");
-
-            IOUtils.copy(in, out);
-            in.close();
-            out.flush();
-            out.close();
-        } catch (IOException e) {
-            log.error("IOException writing JAR File to client: " + jarName, e);
-        }
-
+        IOUtils.copy(in, out);
+        in.close();
+        out.flush();
+        out.close();
     }
 
 

--- a/threadfix-main/src/main/java/com/denimgroup/threadfix/webapp/controller/ToolsDownloadController.java
+++ b/threadfix-main/src/main/java/com/denimgroup/threadfix/webapp/controller/ToolsDownloadController.java
@@ -42,32 +42,25 @@ public class ToolsDownloadController {
 
 	private final SanitizedLogger log = new SanitizedLogger(ToolsDownloadController.class);
 
-    private final static String JAR_DOWNLOAD_DIR = "/WEB-INF/download/";
+    private final static String JAR_DOWNLOAD_DIR = "/WEB-INF/classes/downloads/";
 
-    private final static String CSV2SSVL_JAR = "CSV2SSVL-1.0-SNAPSHOT-jar-with-dependencies.jar";
-    private final static String TF_CLI_JAR = "threadfix-cli-2.2-SNAPSHOT-jar-with-dependencies.jar";
-    private final static String TF_SCAN_IMPORTER_JAR = "threadfix-cli-importers-2.2-SNAPSHOT.jar";
-    private final static String TF_HAM_CLI_JAR = "threadfix-ham-2.2-SNAPSHOT.jar";
-    private final static String TF_DATA_MIGRATION_JAR = "threadfix-data-migration-2.2-SNAPSHOT.jar";
+    private final static String TF_CLI_JAR = "tfcli.jar";
+    private final static String TF_SCAN_IMPORTER_JAR = "threadfix-cli-importers.jar";
+    private final static String TF_ENDPOINT_JAR = "endpoints.jar";
+    private final static String TF_DATA_MIGRATION_JAR = "threadfix-data-migration.jar";
+    private final static String TF_BURP_JAR = "threadfix-release-2-burp.jar";
+    private final static String TF_ZAP = "threadfix-release-2.zap";
+    private final static String TF_SONAR_JAR = "sonar-threadfix-plugin.jar";
+    private final static String CSV2SSVL_JAR = "csv2ssvl.jar";
 
-	public ToolsDownloadController(){}
+
+    public ToolsDownloadController(){}
 	
 	@RequestMapping(method = RequestMethod.GET)
 	public String index() {
 
 		return "config/download/index";
 	}
-
-    @RequestMapping(value="/csv2ssvl")
-    public String doDownloadCsv2ssvl(HttpServletRequest request, HttpServletResponse response) {
-        String destination = null;
-        try {
-            doDownload(request, response, CSV2SSVL_JAR);
-        } catch (Exception e) {
-            destination = "config/download/index";
-        }
-        return destination;
-    }
 
     @RequestMapping(value="/tfcli")
     public String doDownloadTFcli(HttpServletRequest request, HttpServletResponse response) {
@@ -91,11 +84,11 @@ public class ToolsDownloadController {
         return destination;
     }
 
-    @RequestMapping(value="/tfhamcli")
-    public String doDownloadTFhamcli(HttpServletRequest request, HttpServletResponse response) {
+    @RequestMapping(value="/tfendpoint")
+    public String doDownloadTFendcli(HttpServletRequest request, HttpServletResponse response) {
         String destination = null;
         try {
-            doDownload(request, response, TF_HAM_CLI_JAR);
+            doDownload(request, response, TF_ENDPOINT_JAR);
         } catch (Exception e) {
             destination = "config/download/index";
         }
@@ -113,6 +106,51 @@ public class ToolsDownloadController {
         return destination;
     }
 
+    @RequestMapping(value="/burp")
+    public String doDownloadBurp(HttpServletRequest request, HttpServletResponse response) {
+        String destination = null;
+        try {
+            doDownload(request, response, TF_BURP_JAR);
+        } catch (Exception e) {
+            destination = "config/download/index";
+        }
+        return destination;
+    }
+
+    @RequestMapping(value="/zap")
+    public String doDownloadZap(HttpServletRequest request, HttpServletResponse response) {
+        String destination = null;
+        try {
+            doDownload(request, response, TF_ZAP);
+        } catch (Exception e) {
+            destination = "config/download/index";
+        }
+        return destination;
+    }
+
+    @RequestMapping(value="/sonar")
+    public String doDownloadSonar(HttpServletRequest request, HttpServletResponse response) {
+        String destination = null;
+        try {
+            doDownload(request, response, TF_SONAR_JAR);
+        } catch (Exception e) {
+            destination = "config/download/index";
+        }
+        return destination;
+    }
+
+    @RequestMapping(value="/csv2ssvl")
+    public String doDownloadCsv2ssvl(HttpServletRequest request, HttpServletResponse response) {
+        String destination = null;
+        try {
+            doDownload(request, response, CSV2SSVL_JAR);
+        } catch (Exception e) {
+            destination = "config/download/index";
+        }
+        return destination;
+    }
+
+
     private void doDownload(HttpServletRequest request, HttpServletResponse response, String jarName) throws IOException {
 
         String jarResource = JAR_DOWNLOAD_DIR + jarName;
@@ -126,7 +164,10 @@ public class ToolsDownloadController {
         ServletOutputStream out = response.getOutputStream();
         int jarSize = request.getServletContext().getResource(jarResource).openConnection().getContentLength();
 
-        response.setContentType("application/java-archive");
+        if (jarName.endsWith(".jar"))
+            response.setContentType("application/java-archive");
+        else
+            response.setContentType("application/octet-stream");;
         response.setContentLength(jarSize);
         response.addHeader("Content-Disposition", "attachment; filename=\"" + jarName + "\"");
 

--- a/threadfix-main/src/main/java/com/denimgroup/threadfix/webapp/controller/ToolsDownloadController.java
+++ b/threadfix-main/src/main/java/com/denimgroup/threadfix/webapp/controller/ToolsDownloadController.java
@@ -1,0 +1,118 @@
+////////////////////////////////////////////////////////////////////////
+//
+//     Copyright (c) 2009-2015 Denim Group, Ltd.
+//
+//     The contents of this file are subject to the Mozilla Public License
+//     Version 2.0 (the "License"); you may not use this file except in
+//     compliance with the License. You may obtain a copy of the License at
+//     http://www.mozilla.org/MPL/
+//
+//     Software distributed under the License is distributed on an "AS IS"
+//     basis, WITHOUT WARRANTY OF ANY KIND, either express or implied. See the
+//     License for the specific language governing rights and limitations
+//     under the License.
+//
+//     The Original Code is ThreadFix.
+//
+//     The Initial Developer of the Original Code is Denim Group, Ltd.
+//     Portions created by Denim Group, Ltd. are Copyright (C)
+//     Denim Group, Ltd. All Rights Reserved.
+//
+//     Contributor(s): Denim Group, Ltd.
+//
+////////////////////////////////////////////////////////////////////////
+package com.denimgroup.threadfix.webapp.controller;
+
+import com.denimgroup.threadfix.logging.SanitizedLogger;
+import org.apache.commons.io.IOUtils;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+@Controller
+@RequestMapping("/configuration/download")
+public class ToolsDownloadController {
+
+	private final SanitizedLogger log = new SanitizedLogger(ToolsDownloadController.class);
+    private final static String CSV2SSVL_JAR = "CSV2SSVL-1.0-SNAPSHOT-jar-with-dependencies.jar";
+    private final static String TF_CLI_JAR = "threadfix-cli-2.0-jar-with-dependencies.jar";
+    private final static String TF_SCAN_IMPORTER_JAR = "threadfix-cli-importers-2.2-SNAPSHOT.jar";
+    private final static String TF_HAM_CLI_JAR = "threadfix-ham-2.2-SNAPSHOT.jar";
+    private final static String TF_DATA_MIGRATION_JAR = "threadfix-data-migration-2.2-SNAPSHOT.jar";
+
+	public ToolsDownloadController(){}
+	
+	@RequestMapping(method = RequestMethod.GET)
+	public String index() {
+
+		return "config/download/index";
+	}
+
+    @RequestMapping(value="/csv2ssvl")
+    public void doDownloadCsv2ssvl(HttpServletRequest request, HttpServletResponse response) {
+        doDownload(request, response, CSV2SSVL_JAR);
+    }
+
+    @RequestMapping(value="/tfcli")
+    public String doDownloadTFcli(HttpServletRequest request, HttpServletResponse response) {
+        doDownload(request, response, TF_CLI_JAR);
+        return "config/download/index";
+    }
+
+    @RequestMapping(value="/tfscancli")
+    public void doDownloadTFscancli(HttpServletRequest request, HttpServletResponse response) {
+        doDownload(request, response, TF_SCAN_IMPORTER_JAR);
+    }
+
+    @RequestMapping(value="/tfhamcli")
+    public String doDownloadTFhamcli(HttpServletRequest request, HttpServletResponse response) {
+        doDownload(request, response, TF_HAM_CLI_JAR);
+        return "config/download/index";
+    }
+
+    @RequestMapping(value="/tfdatamigration")
+    public String doDownloadTFdatamigration(HttpServletRequest request, HttpServletResponse response) {
+        doDownload(request, response, TF_DATA_MIGRATION_JAR);
+        return "config/download/index";
+    }
+
+    private void doDownload(HttpServletRequest request, HttpServletResponse response, String jarName) {
+
+        String jarResource = "/WEB-INF/download/" + jarName;
+
+        InputStream in = request.getServletContext().getResourceAsStream(jarResource);
+        if (in == null) {
+            log.error("JAR File not found for download: " + jarResource);
+            return;
+        }
+
+        ServletOutputStream out;
+
+        try {
+            out = response.getOutputStream();
+            int jarSize = request.getServletContext().getResource(jarResource).openConnection().getContentLength();
+
+            response.setContentType("application/java-archive");
+            response.setContentLength(jarSize);
+
+            response.addHeader("Content-Disposition", "attachment; filename=\"" + jarName + "\"");
+
+            IOUtils.copy(in, out);
+            in.close();
+            out.flush();
+            out.close();
+        } catch (IOException e) {
+            log.error("IOException writing JAR File to client: " + jarName, e);
+        }
+
+    }
+
+
+}

--- a/threadfix-main/src/main/webapp/WEB-INF/views/config/download/index.jsp
+++ b/threadfix-main/src/main/webapp/WEB-INF/views/config/download/index.jsp
@@ -3,11 +3,10 @@
 <head>
 	<title>Download Tools</title>
 </head>
-
-<%@ include file="/WEB-INF/views/angular-init.jspf"%>
-<%@ include file="/WEB-INF/views/successMessage.jspf" %>
-<%@ include file="/WEB-INF/views/errorMessage.jsp" %>
-
+<body>
+    <%@ include file="/WEB-INF/views/angular-init.jspf"%>
+    <%@ include file="/WEB-INF/views/successMessage.jspf" %>
+    <%@ include file="/WEB-INF/views/errorMessage.jsp" %>
 
     <div id="helpText">
         Tools download page.<br/>

--- a/threadfix-main/src/main/webapp/WEB-INF/views/config/download/index.jsp
+++ b/threadfix-main/src/main/webapp/WEB-INF/views/config/download/index.jsp
@@ -43,7 +43,7 @@
                 <tr>
                     <td>ThreadFix Scan Importer CLI</td>
                     <td>
-                        Wiki
+                        &nbsp;
                     </td>
                     <td><a href="<spring:url value="/configuration/download/tfscancli" htmlEscape="true"/>">
                         Jar File</a></td>
@@ -51,7 +51,7 @@
                 <tr>
                     <td>ThreadFix HAM CLI</td>
                     <td>
-                        Wiki
+                        &nbsp;
                     </td>
                     <td><a href="<spring:url value="/configuration/download/tfhamcli" htmlEscape="true"/>">
                         Jar File</a></td>

--- a/threadfix-main/src/main/webapp/WEB-INF/views/config/download/index.jsp
+++ b/threadfix-main/src/main/webapp/WEB-INF/views/config/download/index.jsp
@@ -1,0 +1,72 @@
+<%@ include file="/common/taglibs.jsp"%>
+
+<head>
+	<title>Download Tools</title>
+</head>
+
+<%@ include file="/WEB-INF/views/angular-init.jspf"%>
+<%@ include file="/WEB-INF/views/successMessage.jspf" %>
+<%@ include file="/WEB-INF/views/errorMessage.jsp" %>
+
+
+    <div id="helpText">
+        Tools download page.<br/>
+    </div>
+
+    <div ng-show="loading" style="float:right" class="modal-loading"><div><span class="spinner dark"></span>Loading...</div></div>
+
+    <div class="container">
+        <h2>Tools Download</h2>
+        <table class="table">
+            <thead>
+                <tr>
+                    <th class="medium first">Tool</th>
+                    <th class="short">Documentation</th>
+                    <th class="short last">Download</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>CSV2SSVL</td>
+                    <td><a target="_blank" href="https://github.com/denimgroup/threadfix/wiki/CSV2SSVL">
+                        Wiki
+                        </a></td>
+                    <td><a href="<spring:url value="/configuration/download/csv2ssvl" htmlEscape="true"/>">
+                        Jar File</a></td>
+                </tr>
+                <tr>
+                    <td>ThreadFix Command Line Interface (CLI)</td>
+                    <td><a target="_blank" href="https://github.com/denimgroup/threadfix/wiki/Command-Line-Interface">
+                        Wiki</a></td>
+                    <td><a href="<spring:url value="/configuration/download/tfcli" htmlEscape="true"/>">
+                        Jar File</a></td>
+                </tr>
+                <tr>
+                    <td>ThreadFix Scan Importer CLI</td>
+                    <td>
+                        Wiki
+                    </td>
+                    <td><a href="<spring:url value="/configuration/download/tfscancli" htmlEscape="true"/>">
+                        Jar File</a></td>
+                </tr>
+                <tr>
+                    <td>ThreadFix HAM CLI</td>
+                    <td>
+                        Wiki
+                    </td>
+                    <td><a href="<spring:url value="/configuration/download/tfhamcli" htmlEscape="true"/>">
+                        Jar File</a></td>
+                </tr>
+                <tr>
+                    <td>ThreadFix Data Migration</td>
+                    <td><a target="_blank" href="https://github.com/denimgroup/threadfix/wiki/Data-Migration-Tool">
+                        Wiki
+                    </a></td>
+                    <td><a href="<spring:url value="/configuration/download/tfdatamigration" htmlEscape="true"/>">
+                        Jar File</a></td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+
+</body>

--- a/threadfix-main/src/main/webapp/WEB-INF/views/config/download/index.jsp
+++ b/threadfix-main/src/main/webapp/WEB-INF/views/config/download/index.jsp
@@ -26,14 +26,6 @@
             </thead>
             <tbody>
                 <tr>
-                    <td>CSV2SSVL</td>
-                    <td><a target="_blank" href="https://github.com/denimgroup/threadfix/wiki/CSV2SSVL">
-                        Wiki
-                        </a></td>
-                    <td><a href="<spring:url value="/configuration/download/csv2ssvl" htmlEscape="true"/>">
-                        Jar File</a></td>
-                </tr>
-                <tr>
                     <td>ThreadFix Command Line Interface (CLI)</td>
                     <td><a target="_blank" href="https://github.com/denimgroup/threadfix/wiki/Command-Line-Interface">
                         Wiki</a></td>
@@ -42,18 +34,17 @@
                 </tr>
                 <tr>
                     <td>ThreadFix Scan Importer CLI</td>
-                    <td>
-                        &nbsp;
-                    </td>
+                    <td><a target="_blank" href="https://github.com/denimgroup/threadfix/wiki/CLI-Importers">
+                        Wiki</a></td>
                     <td><a href="<spring:url value="/configuration/download/tfscancli" htmlEscape="true"/>">
                         Jar File</a></td>
                 </tr>
                 <tr>
-                    <td>ThreadFix HAM CLI</td>
-                    <td>
-                        &nbsp;
-                    </td>
-                    <td><a href="<spring:url value="/configuration/download/tfhamcli" htmlEscape="true"/>">
+                    <td>Endpoint Command Line Interface</td>
+                    <td><a target="_blank" href="https://github.com/denimgroup/threadfix/wiki/Endpoint-CLI">
+                        Wiki
+                    </a></td>
+                    <td><a href="<spring:url value="/configuration/download/tfendpoint" htmlEscape="true"/>">
                         Jar File</a></td>
                 </tr>
                 <tr>
@@ -62,6 +53,38 @@
                         Wiki
                     </a></td>
                     <td><a href="<spring:url value="/configuration/download/tfdatamigration" htmlEscape="true"/>">
+                        Jar File</a></td>
+                </tr>
+                <tr>
+                    <td>Burp Plugin</td>
+                    <td><a target="_blank" href="https://github.com/denimgroup/threadfix/wiki/Burp-Plugin">
+                        Wiki
+                    </a></td>
+                    <td><a href="<spring:url value="/configuration/download/burp" htmlEscape="true"/>">
+                        Jar File</a></td>
+                </tr>
+                <tr>
+                    <td>ZAP Plugin</td>
+                    <td><a target="_blank" href="https://github.com/denimgroup/threadfix/wiki/Zap-Plugin">
+                        Wiki
+                    </a></td>
+                    <td><a href="<spring:url value="/configuration/download/zap" htmlEscape="true"/>">
+                        Zap File</a></td>
+                </tr>
+                <tr>
+                    <td>Sonar Plugin</td>
+                    <td><a target="_blank" href="https://github.com/denimgroup/threadfix/wiki/Using-the-Sonar-Plugin">
+                        Wiki
+                    </a></td>
+                    <td><a href="<spring:url value="/configuration/download/sonar" htmlEscape="true"/>">
+                        Jar File</a></td>
+                </tr>
+                <tr>
+                    <td>CSV2SSVL, CSV to SSVL Tool</td>
+                    <td><a target="_blank" href="https://github.com/denimgroup/threadfix/wiki/CSV2SSVL">
+                        Wiki
+                        </a></td>
+                    <td><a href="<spring:url value="/configuration/download/csv2ssvl" htmlEscape="true"/>">
                         Jar File</a></td>
                 </tr>
             </tbody>

--- a/threadfix-main/src/main/webapp/WEB-INF/web.xml
+++ b/threadfix-main/src/main/webapp/WEB-INF/web.xml
@@ -89,7 +89,7 @@
         		/configuration/keys,/configuration/defecttrackers,/jobs/all,/configuration/remoteproviders,/configuration/grctools,
         		/configuration/users/password,/configuration/users,/configuration/roles,/configuration/logs,/configuration/download,
         		/configuration/settings,/configuration/filters,/configuration/scanqueue,/scanplugin/index,/configuration/tags,/teams,
-        		/j_spring_security_check,/j_spring_security_logout,/images/*,/styles/*,/scripts/*,/rest/*,
+        		/j_spring_security_check,/j_spring_security_logout,/images/*,/styles/*,/scripts/*,/rest/*,/configuration/download/*,
         		regex ^/rest/[a-zA-Z0-9/]*$,
                 regex ^/v/[^/]+/scripts/.*$,
                 regex ^/organizations/[0-9]+/applications/[0-9]+/scans/new/ajax_cwe$,

--- a/threadfix-main/src/main/webapp/WEB-INF/web.xml
+++ b/threadfix-main/src/main/webapp/WEB-INF/web.xml
@@ -87,7 +87,7 @@
 			<param-value>
         		,/,/index.jsp,/login.jsp,/organizations,/about,/wafs,/configuration,/reports,/dashboard,/scans,
         		/configuration/keys,/configuration/defecttrackers,/jobs/all,/configuration/remoteproviders,/configuration/grctools,
-        		/configuration/users/password,/configuration/users,/configuration/roles,/configuration/logs,
+        		/configuration/users/password,/configuration/users,/configuration/roles,/configuration/logs,/configuration/download,
         		/configuration/settings,/configuration/filters,/configuration/scanqueue,/scanplugin/index,/configuration/tags,/teams,
         		/j_spring_security_check,/j_spring_security_logout,/images/*,/styles/*,/scripts/*,/rest/*,
         		regex ^/rest/[a-zA-Z0-9/]*$,

--- a/threadfix-main/src/main/webapp/common/header.jsp
+++ b/threadfix-main/src/main/webapp/common/header.jsp
@@ -142,6 +142,9 @@
 							</security:authorize>
 						</security:authorize>
                         <li class="normalLinks">
+                            <a id="viewDownloadPageLink" href="<spring:url value="/configuration/download" htmlEscape="true"/>">Download Tools</a>
+                        </li>
+                        <li class="normalLinks">
                             <a id="viewAboutPageLink" href="<spring:url value="/about" htmlEscape="true"/>">About</a>
                         </li>
 					</ul>


### PR DESCRIPTION
 pom.xml, Rearrange build order of modules.
threadfix-main/pom.xml, Maven-ant-plugin to copy jars to target/classes/downloads folder.
threadfix-main/src/main/java/com/denimgroup/threadfix/webapp/controller/ToolsDownloadController.java, Controller for Tools Download page.
threadfix-main/src/main/webapp/WEB-INF/views/config/download/index.jsp, View for Tools Download page.
threadfix-main/src/main/webapp/WEB-INF/web.xml, Add configuration/download to entryPoints.
threadfix-main/src/main/webapp/common/header.jsp, Add Download Tools page to Cog menu.