### PR TITLE
Removes deprecated perm gen arguments.

### DIFF
--- a/threadfix-main/util/zip/threadfix.bat
+++ b/threadfix-main/util/zip/threadfix.bat
@@ -13,7 +13,7 @@ SET lib=
 @REM \. on their path
 set PWD=%cd%
 set CATALINA_HOME=%PWD%\tomcat
-set CATALINA_OPTS=-Xms512m -Xmx1536m -XX:PermSize=256m -XX:MaxPermSize=256m
+set CATALINA_OPTS=-Xms512m -Xmx1536m
 if DEFINED JAVA_HOME (
 	"%JAVA_HOME%\bin\java" -version:1.8 -version > nul 2>&1
 	if NOT ERRORLEVEL == 0 (


### PR DESCRIPTION
Java 8 ignores perm gen arguments.