### PR TITLE
DGTF-1676 Setting a vulnerability tag filter on Portfolio Report hide…

### DIFF
--- a/threadfix-main/src/main/webapp/WEB-INF/views/reports/portfolioReport.jsp
+++ b/threadfix-main/src/main/webapp/WEB-INF/views/reports/portfolioReport.jsp
@@ -22,10 +22,6 @@
 			<td class="inputValue">{{title.tags}}</td>
 		</tr>
 		<tr>
-			<td>Vulnerability Tag</td>
-			<td class="inputValue">{{title.vulnTags}}</td>
-		</tr>
-		<tr>
 			<td>Number of Applications</td>
 			<td class="inputValue">{{filterPortfolioApps.length}}</td>
 		</tr>

--- a/threadfix-main/src/main/webapp/WEB-INF/views/vulnerabilities/filterSections.jsp
+++ b/threadfix-main/src/main/webapp/WEB-INF/views/vulnerabilities/filterSections.jsp
@@ -109,7 +109,7 @@
             </div>
         </div>
 
-        <div class="accordion-inner" ng-hide="complianceActive || trendingActive">
+        <div class="accordion-inner" ng-hide="complianceActive || trendingActive || (reportId && reportId == Portfolio_Report_Id)">
             Vulnerability
             <a ng-hide="showVulnTagInput" ng-click="showVulnTagInput = !showVulnTagInput">
                 <span id="showVulnTagInput" class="icon" ng-class="{ 'icon-minus': showVulnTagInput, 'icon-plus': !showVulnTagInput }"></span>

--- a/threadfix-main/src/main/webapp/scripts/report/snapshot-report-controller.js
+++ b/threadfix-main/src/main/webapp/scripts/report/snapshot-report-controller.js
@@ -1020,8 +1020,6 @@ module.controller('SnapshotReportController', function($scope, $rootScope, $wind
             });
             $scope.scanStatistics.push({});
         })
-
-
     };
 
     var filterMVABySeverity = function() {


### PR DESCRIPTION
…s all results

Because Portfolio report is based on Application/Scan, so there is no point to add filter for Vulnerability Tag
--> take it out