### PR TITLE
DGTF-1214 Expose Comment submission in the REST API

### DIFF
--- a/threadfix-cli/src/main/java/com/denimgroup/threadfix/cli/CommandLineParser.java
+++ b/threadfix-cli/src/main/java/com/denimgroup/threadfix/cli/CommandLineParser.java
@@ -309,6 +309,15 @@ public class CommandLineParser {
 
 			} else if (requestAboutTag(cmd)) {
 				processTagRequest(cmd);
+			} else if (cmd.hasOption("ac")) {
+				String[] cmtArgs = cmd.getOptionValues("ac");
+				if (cmtArgs.length < 2) {
+					throw new ParseException("Wrong number of arguments.'");
+				}
+				if (isInteger(cmtArgs[0])) {
+					addVulnComment(cmtArgs);
+				} else
+					LOGGER.warn("VulnId is not number, not doing anything.");
 			}  else {
 				throw new ParseException("No arguments found.");
 			}
@@ -318,6 +327,27 @@ public class CommandLineParser {
 			HelpFormatter formatter = new HelpFormatter();
 			formatter.printHelp("java -jar tfcli.jar", options);
 		}
+	}
+
+	private static void addVulnComment(String[] cmtArgs) {
+		if (cmtArgs[1] == null || cmtArgs[1].trim().isEmpty()) {
+			LOGGER.error("Comment cannot be empty");
+			return;
+		}
+		String tagIds = null;
+		if (cmtArgs.length > 2) {
+			tagIds = cmtArgs[2];
+			if (tagIds != null) {
+				String[] ids = tagIds.split(",");
+				for (String id: ids) {
+					if (!isInteger(id.trim())) {
+						LOGGER.error(id + " is not a number.");
+						return;
+					}
+				}
+			}
+		}
+		printOutput(client.addVulnComment(Integer.valueOf(cmtArgs[0]), cmtArgs[1], tagIds));
 	}
 
 	private static void processTagRequest(CommandLine cmd) throws ParseException {

--- a/threadfix-cli/src/main/java/com/denimgroup/threadfix/cli/OptionsHolder.java
+++ b/threadfix-cli/src/main/java/com/denimgroup/threadfix/cli/OptionsHolder.java
@@ -179,7 +179,6 @@ public class OptionsHolder {
                 .create("stg");
         options.addOption(searchTag);
 
-
         Option updateTag = OptionBuilder.withArgName("tagId> <name")
                 .hasArgs(2)
                 .withLongOpt("update-tag")
@@ -187,15 +186,12 @@ public class OptionsHolder {
                 .create("utg");
         options.addOption(updateTag);
 
-
         Option removeTag = OptionBuilder.withArgName("tagId")
                 .hasArgs(1)
                 .withLongOpt("remove-tag")
                 .withDescription("Remove ThreadFix Tag, and returns message.")
                 .create("rtg");
         options.addOption(removeTag);
-
-
 
         Option tags = OptionBuilder.withLongOpt("tags")
                 .withDescription("Fetches a list of ThreadFix tags.")
@@ -217,6 +213,13 @@ public class OptionsHolder {
                 .withDescription("Remove Tag for the given applicationId")
                 .create("rat");
         options.addOption(removeAppTag);
+
+        Option addComment = OptionBuilder.withArgName("vulnId> <comment> <[commentTagIds]")
+                .hasArgs(3)
+                .withLongOpt("add-comment")
+                .withDescription("Add comment to a vulnerability. CommentTagIds is optional, separated by comma.")
+                .create("ac");
+        options.addOption(addComment);
 
         return options;
     }

--- a/threadfix-cli/src/main/java/com/denimgroup/threadfix/remote/ThreadFixRestClient.java
+++ b/threadfix-cli/src/main/java/com/denimgroup/threadfix/remote/ThreadFixRestClient.java
@@ -99,4 +99,6 @@ public interface ThreadFixRestClient {
     public RestResponse<String> removeTag(String tagId);
 
     void setUnsafeFlag(boolean unsafeFlag);
+
+    RestResponse<String> addVulnComment(Integer vulnId, String comment, String commentTagIds);
 }

--- a/threadfix-cli/src/main/java/com/denimgroup/threadfix/remote/ThreadFixRestClientImpl.java
+++ b/threadfix-cli/src/main/java/com/denimgroup/threadfix/remote/ThreadFixRestClientImpl.java
@@ -403,4 +403,12 @@ public class ThreadFixRestClientImpl implements ThreadFixRestClient {
     public void setUnsafeFlag(boolean unsafeFlag) {
         this.httpRestUtils.setUnsafeFlag(unsafeFlag);
     }
+
+    @Override
+    public RestResponse<String> addVulnComment(Integer vulnId, String comment, String commentTagIds) {
+        return httpRestUtils.httpPost("/vulnerabilities/" + vulnId + "/addComment",
+                new String[] { "comment", "commentTagIds" },
+                new String[] { comment, commentTagIds }, String.class);
+    }
+
 }

--- a/threadfix-main/src/main/java/com/denimgroup/threadfix/service/VulnerabilityCommentServiceImpl.java
+++ b/threadfix-main/src/main/java/com/denimgroup/threadfix/service/VulnerabilityCommentServiceImpl.java
@@ -28,6 +28,7 @@ import com.denimgroup.threadfix.data.dao.UserDao;
 import com.denimgroup.threadfix.data.dao.VulnerabilityCommentDao;
 import com.denimgroup.threadfix.data.dao.VulnerabilityDao;
 import com.denimgroup.threadfix.data.entities.*;
+import com.denimgroup.threadfix.data.enums.TagType;
 import com.denimgroup.threadfix.logging.SanitizedLogger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -35,9 +36,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Nullable;
+import javax.servlet.http.HttpServletRequest;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
+
+import static com.denimgroup.threadfix.CollectionUtils.list;
 
 @Service
 @Transactional
@@ -54,6 +58,8 @@ public class VulnerabilityCommentServiceImpl implements VulnerabilityCommentServ
     @Autowired(required = false)
     @Nullable
     private PermissionService permissionService;
+	@Autowired
+	private TagService tagService;
 
 	@Override
 	public List<VulnerabilityComment> loadAllForVuln(Integer vulnId) {
@@ -107,7 +113,64 @@ public class VulnerabilityCommentServiceImpl implements VulnerabilityCommentServ
 
 		return VALID;
 	}
-	
+
+	@Override
+	public String addCommentToVulnFromRest(HttpServletRequest request, Integer vulnId, ThreadFixUserDetails userDetails) {
+
+
+		String comment = request.getParameter("comment");
+
+		String tagIds = request.getParameter("commentTagIds");
+
+		if (comment == null || comment.trim().isEmpty()) {
+			log.error("Invalid comment string.");
+			return EMPTY;
+		}
+
+		String trimmedComment = comment.trim().replace("\r\n", "\n");
+
+		if (trimmedComment.length() > VulnerabilityComment.COMMENT_LENGTH) {
+			log.error("String was too long.");
+			return LENGTH;
+		}
+
+		if (vulnId == null) {
+			log.error("Invalid vuln ID");
+			return VULN;
+		}
+
+		Vulnerability vuln = vulnerabilityDao.retrieveById(vulnId);
+
+		if (vuln == null) {
+			log.error("Invalid vuln ID");
+			return VULN;
+		}
+
+		User user = userDao.retrieveById(userDetails.getUserId());
+
+		if (user == null) {
+			log.error("Invalid user.");
+			return USER;
+		}
+
+		List<Tag> tagList = list();
+		String tagChecking = checkTags(tagIds, tagList);
+		if (tagChecking != null) {
+			log.error(tagChecking);
+			return tagChecking;
+		}
+
+		VulnerabilityComment vulnerabilityComment = new VulnerabilityComment();
+		vulnerabilityComment.setTags(tagList);
+		vulnerabilityComment.setComment(trimmedComment);
+		vulnerabilityComment.setVulnerability(vuln);
+		vulnerabilityComment.setTime(new Date());
+		vulnerabilityComment.setUser(user);
+		vulnerabilityCommentDao.saveOrUpdate(vulnerabilityComment);
+
+		return VALID;
+	}
+
 	@Override
 	public List<VulnerabilityComment> loadMostRecentFiltered(int number) {
 		if (permissionService == null || permissionService.isAuthorized(Permission.READ_ACCESS, null, null)) {
@@ -129,4 +192,34 @@ public class VulnerabilityCommentServiceImpl implements VulnerabilityCommentServ
     public VulnerabilityComment loadVulnerabilityCommentById(int commentId) {
         return vulnerabilityCommentDao.retrieveById(commentId);
     }
+
+	private String checkTags(String tagIds, List<Tag> tagList) {
+		if (tagIds == null || tagIds.trim().isEmpty()) {
+			return null;
+		}
+
+		String[] ids = tagIds.split(",");
+
+		for (String idStr: ids) {
+			if (idStr == null || idStr.trim().isEmpty()) {
+				return "Invalid comment tags.";
+			}
+
+			try {
+				Tag dbTag = tagService.loadTag(Integer.valueOf(idStr.trim()));
+				if (dbTag == null) {
+					return "Couldn't find tag with ID " + idStr;
+				}
+
+				if (dbTag.getType() != TagType.COMMENT) {
+					return "Tag with ID " + idStr + " is not a vulnerability comment tag.";
+				} else {
+					tagList.add(dbTag);
+				}
+			} catch(NumberFormatException e) {
+				return idStr + " is not an ID.";
+			}
+		}
+		return null;
+	}
 }

--- a/threadfix-main/src/main/java/com/denimgroup/threadfix/webapp/controller/rest/VulnerabilityRestController.java
+++ b/threadfix-main/src/main/java/com/denimgroup/threadfix/webapp/controller/rest/VulnerabilityRestController.java
@@ -23,13 +23,14 @@
 ////////////////////////////////////////////////////////////////////////
 package com.denimgroup.threadfix.webapp.controller.rest;
 
+import com.denimgroup.threadfix.data.entities.Permission;
+import com.denimgroup.threadfix.data.entities.Vulnerability;
+import com.denimgroup.threadfix.data.entities.VulnerabilityComment;
 import com.denimgroup.threadfix.data.entities.VulnerabilitySearchParameters;
 import com.denimgroup.threadfix.logging.SanitizedLogger;
 import com.denimgroup.threadfix.remote.response.RestResponse;
-import com.denimgroup.threadfix.service.ChannelTypeService;
-import com.denimgroup.threadfix.service.OrganizationService;
-import com.denimgroup.threadfix.service.ThreadFixUserDetails;
-import com.denimgroup.threadfix.service.VulnerabilitySearchService;
+import com.denimgroup.threadfix.service.*;
+import com.denimgroup.threadfix.service.util.PermissionUtils;
 import com.denimgroup.threadfix.util.Result;
 import com.denimgroup.threadfix.views.AllViews;
 import com.denimgroup.threadfix.webapp.controller.NumericDatePropertyEditorSupport;
@@ -42,6 +43,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.Date;
+import java.util.List;
 
 import static com.denimgroup.threadfix.remote.response.RestResponse.resultError;
 import static com.denimgroup.threadfix.webapp.controller.rest.RestMethod.APPLICATION_SCAN_LIST;
@@ -51,9 +53,9 @@ import static com.denimgroup.threadfix.webapp.controller.rest.RestMethod.APPLICA
  */
 @RestController
 @RequestMapping("/rest/vulnerabilities")
-public class VulnerabilitySearchRestController extends TFRestController {
+public class VulnerabilityRestController extends TFRestController {
 
-    private static final SanitizedLogger LOG = new SanitizedLogger(VulnerabilitySearchRestController.class);
+    private static final SanitizedLogger LOG = new SanitizedLogger(VulnerabilityRestController.class);
 
     @Autowired
     public VulnerabilitySearchService vulnerabilitySearchService;
@@ -61,6 +63,10 @@ public class VulnerabilitySearchRestController extends TFRestController {
     public OrganizationService organizationService;
     @Autowired
     public ChannelTypeService channelTypeService;
+    @Autowired
+    public VulnerabilityService vulnerabilityService;
+    @Autowired
+    public VulnerabilityCommentService vulnerabilityCommentService;
 
     // Turn Date.getTime() javascript numbers into java.util.Date objects.
     @InitBinder
@@ -105,6 +111,41 @@ public class VulnerabilitySearchRestController extends TFRestController {
 
         serialized = writer.writeValueAsString(response);
         return serialized;
+    }
+
+    @RequestMapping(value="/{vulnId}/addComment", method = RequestMethod.POST)
+    public Object addComment(HttpServletRequest request,
+                             @PathVariable("vulnId") int vulnId) {
+        ThreadFixUserDetails user = getUserDetailsFromApiKeyInRequest(request);
+        if (user == null) {
+            return RestResponse.failure("Your API key is not valid, it is not attached to any user. " +
+                    "ThreadFix needs API key that is attached to users to add comment from REST API.");
+        }
+
+        Vulnerability vulnerability = vulnerabilityService.loadVulnerability(vulnId);
+        if (vulnerability == null) {
+            return RestResponse.failure("Couldn't find vulnerability with Id " + vulnId + ".");
+        }
+
+        int orgId = vulnerability.getTeamId();
+        int appId = vulnerability.getAppId();
+
+        if (!PermissionUtils.isAuthorized(user, Permission.CAN_SUBMIT_COMMENTS, orgId, appId) &&
+                !PermissionUtils.isAuthorized(user, Permission.CAN_MODIFY_VULNERABILITIES, orgId, appId)) {
+            return RestResponse.failure("You don't have permission to add comment to this vulnerability.");
+        }
+
+        String result = vulnerabilityCommentService.addCommentToVulnFromRest(request, vulnId, user);
+
+        if (result == null) {
+            result = "The submitted comment was invalid.";
+        }
+
+        if (!result.equals(VulnerabilityCommentService.VALID)) {
+            return RestResponse.failure(result);
+        }
+
+        return RestResponse.success("Comment added successfully.");
 
     }
 

--- a/threadfix-service-interfaces/src/main/java/com/denimgroup/threadfix/service/VulnerabilityCommentService.java
+++ b/threadfix-service-interfaces/src/main/java/com/denimgroup/threadfix/service/VulnerabilityCommentService.java
@@ -26,6 +26,7 @@ package com.denimgroup.threadfix.service;
 
 import com.denimgroup.threadfix.data.entities.VulnerabilityComment;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 
 public interface VulnerabilityCommentService {
@@ -37,6 +38,8 @@ public interface VulnerabilityCommentService {
 	List<VulnerabilityComment> loadAllForVuln(Integer vulnerabilityId);
 
 	String addCommentToVuln(VulnerabilityComment comment, Integer vulnerabilityId);
+
+	String addCommentToVulnFromRest(HttpServletRequest request, Integer vulnerabilityId, ThreadFixUserDetails user);
 
 	List<VulnerabilityComment> loadMostRecentFiltered(int number);
 


### PR DESCRIPTION
Implemented by second solution: API keys needs to be attached with user.
Usage: -ac <vulnId> <comment> <[commentTagIds]>
CommentTagIds is optional, separated by comma.