### PR TITLE
Added a filter to remove non-word characters

### DIFF
--- a/threadfix-main/src/main/webapp/scripts/filters.js
+++ b/threadfix-main/src/main/webapp/scripts/filters.js
@@ -28,3 +28,11 @@ filtersModule.filter('removeSpace', function() {
     }
 });
 
+filtersModule.filter('removeNonWord', function() {
+    return function(input) {
+        if (input) {
+            return input.replace(/\W/g, '');
+        }
+    }
+});
+


### PR DESCRIPTION
This filter can be used to remove non-word characters from IDs, and will be used for elements such as email addresses.