### PR TITLE
DGTF-1899 No "Critical" severity for Manual Findings in MySQL

### DIFF
--- a/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateChannelSeverityDao.java
+++ b/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateChannelSeverityDao.java
@@ -55,14 +55,27 @@ public class HibernateChannelSeverityDao implements ChannelSeverityDao {
 
 	@Override
 	public ChannelSeverity retrieveByCode(ChannelType channelType, String code) {
-		return (ChannelSeverity) sessionFactory
+
+		// To avoid case insensitive query in MySQL
+		List<ChannelSeverity> channelSeverities = (List<ChannelSeverity>) sessionFactory
 				.getCurrentSession()
 				.createQuery(
 						"from ChannelSeverity cs where cs.code = :code "
 								+ "and cs.channelType = :channelTypeId")
 				.setString("code", code)
 				.setInteger("channelTypeId", channelType.getId())
-				.uniqueResult();
+				.list();
+
+		if (channelSeverities == null || channelSeverities.size() == 0)
+			return null;
+
+		for (ChannelSeverity channelSeverity: channelSeverities) {
+			if (code.equals(channelSeverity.getCode()))
+				return channelSeverity;
+		}
+
+		return null;
+
 	}
 
 	@Override

--- a/threadfix-importers/src/main/resources/mappings/scanner/appscan.csv
+++ b/threadfix-importers/src/main/resources/mappings/scanner/appscan.csv
@@ -1,4 +1,4 @@
-6/9/2015 11:47:00
+09/02/2015 11:47:00
 type.info,,
 IBM Security AppScan Standard,,
 type.vulnerabilities,,
@@ -72,7 +72,7 @@ Weak SSL Cipher Suites are Supported,Weak SSL Cipher Suites are Supported,327
 Internal IP Disclosure Pattern Found,Internal IP Disclosure Pattern Found,200
 Potential File Upload,Potential File Upload,434
 Email-Parameter Spoofing,Email-Parameter Spoofing,472
-Directory Listing Pattern Found,Directory Listing Pattern Found,Directory Listing Pattern Found,Directory Listing Pattern Found,548
+Directory Listing Pattern Found,Directory Listing Pattern Found,548
 Microsoft Windows MHTML Cross-Site Scripting,Microsoft Windows MHTML Cross-Site Scripting,79
 Microsoft ASP.NET Debugging Enabled,Microsoft ASP.NET Debugging Enabled,11
 Apache server-status Information Disclosure,Apache server-status Information Disclosure,200

--- a/threadfix-importers/src/main/resources/mappings/scanner/codeprofiler.csv
+++ b/threadfix-importers/src/main/resources/mappings/scanner/codeprofiler.csv
@@ -1,17 +1,17 @@
-2/18/2015 3:50:00,,,,
+9/02/2015 3:50:00,,,,
 type.info,,,,
 CodeProfiler,https://www.virtualforge.com/,3.8,Do a manual scan,
 type.vulnerabilities,,
 1 Cross-Site Scripting,Cross-Site Scripting,79
 2 Denial of Service (DOS) in DO Loop,Denial of Service (DOS) in DO Loop,400
 4 Hard-coded User Name (sy-uname),Hard-coded User Name (sy-uname),285
-5 All Occurrences of sy-uname,All Occurrences of sy-uname,0
+5 All Occurrences of sy-uname,All Occurrences of sy-uname,16
 8 Dangerous ABAP Commands,Dangerous ABAP Commands,242
 9 Direct Database Modifications,Direct Database Modifications,389
 14 Missing AUTHORITY-CHECK in RFC-Enabled Functions,Missing AUTHORITY-CHECK in RFC-Enabled Functions,862
 15 Missing AUTHORITY-CHECK before CALL TRANSACTION,Missing AUTHORITY-CHECK before CALL TRANSACTION,862
 18 OSQL Injection (Write Access),OSQL Injection (Write Access),89
-20 Usage of Regular Expression,Usage of Regular Expression,0
+20 Usage of Regular Expression,Usage of Regular Expression,185
 21 Forceful Querying (Write Access),Forceful Querying (Write Access),639
 22 Generic ABAP Module Calls,Generic ABAP Module Calls,99
 24 Directory Traversal (Write Access),Directory Traversal (Write Access),22
@@ -25,15 +25,15 @@ type.vulnerabilities,,
 34 ABAP Command Injection (report),ABAP Command Injection (report),96
 35 ABAP Command Injection (program),ABAP Command Injection (program),95
 36 Exposed Kernel Calls,Exposed Kernel Calls,242
-39 Unmanaged SQL,Unmanaged SQL,0
+39 Unmanaged SQL,Unmanaged SQL,89
 41 OS Command Execution (Parameter),OS Command Execution (Parameter),78
 43 Phishing,Phishing,442
 44 OS Command Injection (OPEN DATASET; Filter),OS Command Injection (OPEN DATASET; Filter),
 45 Hard-coded SAP System ID Checks (sy-sysid),Hard-coded SAP System ID Checks (sy-sysid),398
 46 Cross-Client Access to Business Data,Cross-Client Access to Business Data,265
 48 Generic RFC Destinations,Generic RFC Destinations,95
-49 File Upload (SAP GUI),File Upload (SAP GUI),0
-50 File Download (SAP GUI),File Download (SAP GUI),0
+49 File Upload (SAP GUI),File Upload (SAP GUI),434
+50 File Download (SAP GUI),File Download (SAP GUI),494
 52 OS Command Execution (Client OS),OS Command Execution (Client OS),78
 53 Hard-coded SAP Client Checks (sy-mandt),Hard-coded SAP Client Checks (sy-mandt),398
 56 Hard-coded System Date Checks (sy-datum),Hard-coded System Date Checks (sy-datum),398
@@ -42,7 +42,7 @@ type.vulnerabilities,,
 71 SQL Injection (Native),SQL Injection (Native),89
 80 Missing AUTHORITY-CHECK in Reports,Missing AUTHORITY-CHECK in Reports,862
 82 Hidden ABAP Code,Hidden ABAP Code,503
-84 Outgoing FTP Connections,Outgoing FTP Connections,0
+84 Outgoing FTP Connections,Outgoing FTP Connections,16
 85 Forceful Querying (Read Access),Forceful Querying (Read Access),639
 87 Generic Table Query (Read Access),Generic Table Query (Read Access),639
 88 Generic Table Query (Write Access),Generic Table Query (Write Access),639
@@ -81,9 +81,9 @@ type.vulnerabilities,,
 232 Privileging AUTHORITY-CHECKs (AUTHC),Privileging AUTHORITY-CHECKs (AUTHC),863
 233 Privileging AUTHORITY-CHECKs (CO_ACTION),Privileging AUTHORITY-CHECKs (CO_ACTION),863
 234 Usage of pseudo-cryptographic Algorithms,Usage of pseudo-cryptographic Algorithms,398
-235 Deactivation of Table-Change Logging,Deactivation of Table-Change Logging,0
+235 Deactivation of Table-Change Logging,Deactivation of Table-Change Logging,16
 237 Cross-Client Data Transfer,Cross-Client Data Transfer,265
-239 OS Command Injection (OPEN DATASET; File Name),OS Command Injection (OPEN DATASET; File Name),
+239 OS Command Injection (OPEN DATASET; File Name),OS Command Injection (OPEN DATASET; File Name),78
 240 Hard-coded Alias Authorization in AUTHORITY-CHECK,Hard-coded Alias Authorization in AUTHORITY-CHECK,863
 241 SQL Injection on In-Memory Tables (Read Access),SQL Injection on In-Memory Tables (Read Access),89
 242 SQL Injection on In-Memory Tables (Write Access),SQL Injection on In-Memory Tables (Write Access),89

--- a/threadfix-importers/src/main/resources/mappings/scanner/manual.csv
+++ b/threadfix-importers/src/main/resources/mappings/scanner/manual.csv
@@ -1,9 +1,10 @@
-2/25/2015 8:28:00
+9/3/2015 8:28:00
 type.info,,,
 Manual
 type.vulnerabilities,,,
 type.severities,,,
 No Threat,No Threat,1,1
+Critical,Critical,5,5
 critical,critical,5,5
 severe,severe,4,4
 moderate,moderate,3,3


### PR DESCRIPTION
MySQL is case insensitive query, that's why when run scanner mapping updater, it overrides "Critical" to "critical"