### PR TITLE
Stable-bugfix

### DIFF
--- a/threadfix-main/src/main/webapp/scripts/services.js
+++ b/threadfix-main/src/main/webapp/scripts/services.js
@@ -491,7 +491,7 @@ threadfixModule.factory('vulnTreeTransformer', function() {
 
                 var newTreeCategory = getCategory(owaspVuln.name, 5);
                 vulnList.forEach(function(element) {
-                    if (owaspVuln.members.indexOf(element.genericVulnerability.displayId) > -1
+                    if ((owaspVuln.members.indexOf(element.genericVulnerability.displayId) > -1 && !element.memberOf)
                         || (element.memberOf && owaspVuln.members.indexOf(element.memberOf) > -1)) {
                         newTreeCategory.total = newTreeCategory.total + element.numResults;
                         newTreeCategory.entries.push(element);


### PR DESCRIPTION
DGTF-2003 Dependency Check vulnerabilities appear twice in OWASP Top 10 report
DGTF-1977 Imported Sonatype vulnerabilities listed twice in OWASP Top 10 report