### PR TITLE
DGTF-1174 Added the Apache Commons URL Validator to HttpRestUtils. We now valid…

### DIFF
--- a/threadfix-cli/pom.xml
+++ b/threadfix-cli/pom.xml
@@ -113,6 +113,11 @@
             <version>${commons.io.version}</version>
         </dependency>
         <dependency>
+            <groupId>commons-validator</groupId>
+            <artifactId>commons-validator</artifactId>
+            <version>${commons.validator.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
             <version>${gson.version}</version>

--- a/threadfix-scanner-plugin/burp/src/main/java/burp/BurpExtender.java
+++ b/threadfix-scanner-plugin/burp/src/main/java/burp/BurpExtender.java
@@ -340,13 +340,11 @@ public class BurpExtender implements IBurpExtender, ITab
 
         @Override
         public void focusGained(FocusEvent e) {
-            System.out.println("focusGained -- " + jTextField.getText());
             lastValue = jTextField.getText().trim();
         }
 
         @Override
         public void focusLost(FocusEvent e) {
-            System.out.println("focusLost -- " + jTextField.getText());
             String currentValue = jTextField.getText().trim();
             if (!currentValue.equals(lastValue)) {
                 update();


### PR DESCRIPTION
…ate the base URL before forming GET and POST URLs. This can prevent having to wait for a timeout when an invalid or incomplete URL is entered. Removed debugging println commands.