### PR TITLE
DGTF-1656 Scan index page does not show count by severity for Manual Findings

### DIFF
--- a/threadfix-main/src/main/java/com/denimgroup/threadfix/service/ManualFindingServiceImpl.java
+++ b/threadfix-main/src/main/java/com/denimgroup/threadfix/service/ManualFindingServiceImpl.java
@@ -185,6 +185,25 @@ public class ManualFindingServiceImpl implements ManualFindingService {
 
 		scan.getFindings().add(finding);
 		scan.setNumberTotalVulnerabilities(scan.getNumberTotalVulnerabilities() + 1);
+
+        switch (finding.getChannelSeverity().getCode()) {
+            case GenericSeverity.CRITICAL:
+                scan.setNumberCriticalVulnerabilities( scan.getNumberCriticalVulnerabilities() + 1 );
+                break;
+            case GenericSeverity.HIGH:
+                scan.setNumberHighVulnerabilities(scan.getNumberHighVulnerabilities() + 1);
+                break;
+            case GenericSeverity.MEDIUM:
+                scan.setNumberMediumVulnerabilities(scan.getNumberMediumVulnerabilities() + 1);
+                break;
+            case GenericSeverity.LOW:
+                scan.setNumberLowVulnerabilities(scan.getNumberLowVulnerabilities() + 1);
+                break;
+            case GenericSeverity.INFO:
+                scan.setNumberInfoVulnerabilities( scan.getNumberInfoVulnerabilities() + 1 );
+                break;
+        }
+
         scanCleanerUtils.clean(scan);
 
 		vulnerabilityService.storeVulnerability(finding.getVulnerability());


### PR DESCRIPTION
When processing a manual finding, increment the counter for the severity (Critical, High, Medium, Low, Info).