### PR TITLE
DGTF-2052 Importing WhiteHat scans can take exceptionally long time o…

### DIFF
--- a/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/ScanDao.java
+++ b/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/ScanDao.java
@@ -186,9 +186,17 @@ public interface ScanDao extends GenericObjectDao<Scan> {
 
 	List<Finding> getFindingsThatNeedCounters(int page);
 
+	Long totalFindingsThatNeedCountersInApps(List<Integer> appIds);
+
+	List<Finding> getFindingsThatNeedCountersInApps(int page, List<Integer> appIds);
+
 	List<ScanRepeatFindingMap> getMapsThatNeedCounters(int current);
 
 	Long totalMapsThatNeedCounters();
+
+	List<ScanRepeatFindingMap> getMapsThatNeedCountersInApps(int current, List<Integer> appIds);
+
+	Long totalMapsThatNeedCountersInApps(List<Integer> appIds);
 
 }
 

--- a/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateScanDao.java
+++ b/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateScanDao.java
@@ -424,7 +424,15 @@ public class HibernateScanDao
 		
         return filteredCriteria.list();
 	}
-	
+
+	@Override
+	public List<Scan> retrieveAll() {
+		Criteria criteria = getBaseScanCriteria()
+				.addOrder(getOrder());
+
+		return criteria.list();
+	}
+
 	@Override
 	public int getScanCount() {
 
@@ -508,6 +516,33 @@ public class HibernateScanDao
 				.list();
 	}
 
+	@Override
+	public List<Finding> getFindingsThatNeedCountersInApps(int page, List<Integer> appIds) {
+		if (appIds == null)
+			return getFindingsThatNeedCounters(page);
+
+		return getBaseCounterCriteria()
+				.add(in("appAlias.id", appIds))
+				.setMaxResults(100)
+				.setFirstResult(page * 100)
+				.list();
+	}
+
+	@Override
+	public Long totalFindingsThatNeedCounters() {
+		return (Long) getBaseCounterCriteria().setProjection(rowCount()).uniqueResult();
+	}
+
+	@Override
+	public Long totalFindingsThatNeedCountersInApps(List<Integer> appIds) {
+		if (appIds == null)
+			return totalFindingsThatNeedCounters();
+
+		return (Long) getBaseCounterCriteria()
+				.add(in("appAlias.id", appIds))
+				.setProjection(rowCount()).uniqueResult();
+	}
+
 	private Criteria getBaseCounterCriteria() {
 		return sessionFactory.getCurrentSession().createCriteria(Finding.class)
 				.createAlias("vulnerability", "vulnAlias")
@@ -516,11 +551,6 @@ public class HibernateScanDao
 				.add(eq("appAlias.active", true))
 				.add(isEmpty("statisticsCounters"))
 				;
-	}
-
-	@Override
-	public Long totalFindingsThatNeedCounters() {
-		return (Long) getBaseCounterCriteria().setProjection(rowCount()).uniqueResult();
 	}
 
 	@Override
@@ -533,6 +563,28 @@ public class HibernateScanDao
 	@Override
 	public Long totalMapsThatNeedCounters() {
 		return (Long) getBasicMapCriteria().setProjection(rowCount()).uniqueResult();
+	}
+
+	@Override
+	public List<ScanRepeatFindingMap> getMapsThatNeedCountersInApps(int current, List<Integer> appIds) {
+		if (appIds == null)
+			return getMapsThatNeedCounters(current);
+
+		return getBasicMapCriteria()
+				.add(in("appAlias.id", appIds))
+				.setMaxResults(100)
+				.setFirstResult(current * 100)
+				.list();
+	}
+
+	@Override
+	public Long totalMapsThatNeedCountersInApps(List<Integer> appIds) {
+		if (appIds == null)
+			return totalMapsThatNeedCounters();
+
+		return (Long) getBasicMapCriteria()
+				.add(in("appAlias.id", appIds))
+				.setProjection(rowCount()).uniqueResult();
 	}
 
 	private Criteria getBasicMapCriteria() {

--- a/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateScanDao.java
+++ b/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateScanDao.java
@@ -510,7 +510,10 @@ public class HibernateScanDao
 
 	private Criteria getBaseCounterCriteria() {
 		return sessionFactory.getCurrentSession().createCriteria(Finding.class)
+				.createAlias("vulnerability", "vulnAlias")
+				.createAlias("vulnAlias.application", "appAlias")
 				.add(eq("firstFindingForVuln", true))
+				.add(eq("appAlias.active", true))
 				.add(isEmpty("statisticsCounters"))
 				;
 	}
@@ -534,6 +537,9 @@ public class HibernateScanDao
 
 	private Criteria getBasicMapCriteria() {
 		return sessionFactory.getCurrentSession().createCriteria(ScanRepeatFindingMap.class)
+				.createAlias("scan", "scanAlias")
+				.createAlias("scanAlias.application", "appAlias")
+				.add(eq("appAlias.active", true))
 				.add(isEmpty("statisticsCounters"))
 				;
 	}

--- a/threadfix-importers/src/main/java/com/denimgroup/threadfix/service/StatisticsCounterServiceImpl.java
+++ b/threadfix-importers/src/main/java/com/denimgroup/threadfix/service/StatisticsCounterServiceImpl.java
@@ -67,12 +67,18 @@ public class StatisticsCounterServiceImpl implements StatisticsCounterService {
 
     @Override
     public void checkStatisticsCounters() {
-        addMissingFindingCounters();
-        addMissingMapCounters();
+        addMissingFindingCounters(null);
+        addMissingMapCounters(null);
     }
 
-    private void addMissingMapCounters() {
-        Long total = scanDao.totalMapsThatNeedCounters();
+    @Override
+    public void checkStatisticsCountersInApps(List<Integer> appIds) {
+        addMissingFindingCounters(appIds);
+        addMissingMapCounters(appIds);
+    }
+
+    private void addMissingMapCounters(List<Integer> appIds) {
+        Long total = scanDao.totalMapsThatNeedCountersInApps(appIds);
 
         long start = System.currentTimeMillis();
 
@@ -84,7 +90,7 @@ public class StatisticsCounterServiceImpl implements StatisticsCounterService {
 
             LOG.debug("Processing " + current + " out of " + total + ".");
 
-            List<ScanRepeatFindingMap> mapsThatNeedCounters = scanDao.getMapsThatNeedCounters(current);
+            List<ScanRepeatFindingMap> mapsThatNeedCounters = scanDao.getMapsThatNeedCountersInApps(current, appIds);
 
             for (ScanRepeatFindingMap map : mapsThatNeedCounters) {
                 if (!map.getFinding().isFirstFindingForVuln()) {
@@ -102,8 +108,8 @@ public class StatisticsCounterServiceImpl implements StatisticsCounterService {
         LOG.debug("Took " + (System.currentTimeMillis() - start) + " ms to add missing map counters.");
     }
 
-    private void addMissingFindingCounters() {
-        Long total = scanDao.totalFindingsThatNeedCounters();
+    private void addMissingFindingCounters(List<Integer> appIds) {
+        Long total = scanDao.totalFindingsThatNeedCountersInApps(appIds);
 
         long start = System.currentTimeMillis();
 
@@ -115,7 +121,7 @@ public class StatisticsCounterServiceImpl implements StatisticsCounterService {
 
             LOG.debug("Processing at index " + current + " out of " + total);
 
-            List<Finding> findingsThatNeedCounters = scanDao.getFindingsThatNeedCounters(current);
+            List<Finding> findingsThatNeedCounters = scanDao.getFindingsThatNeedCountersInApps(current, appIds);
 
             for (Finding finding : findingsThatNeedCounters) {
                 if (!finding.isFirstFindingForVuln()) {

--- a/threadfix-main/src/main/java/com/denimgroup/threadfix/service/VulnerabilityFilterServiceImpl.java
+++ b/threadfix-main/src/main/java/com/denimgroup/threadfix/service/VulnerabilityFilterServiceImpl.java
@@ -350,13 +350,13 @@ public class VulnerabilityFilterServiceImpl implements VulnerabilityFilterServic
 			log.debug("team");
 
 			List<Integer> applicationIdList = list();
-			for (Application application : organization.getApplications()) {
+			for (Application application : organization.getActiveApplications()) {
 				if (application != null) {
 					applicationIdList.add(application.getId());
 				}
 			}
 
-			statisticsCounterService.checkStatisticsCounters();
+			statisticsCounterService.checkStatisticsCountersInApps(applicationIdList);
 			updateVulnerabilities(organization, applicationIdList);
 			updateScanCounts(scanDao.retrieveByApplicationIdList(applicationIdList));
 		}
@@ -430,7 +430,7 @@ public class VulnerabilityFilterServiceImpl implements VulnerabilityFilterServic
 	private void updateApplicationVulnerabilities(Application application) {
 
 		if (application != null) {
-			statisticsCounterService.checkStatisticsCounters();
+			statisticsCounterService.checkStatisticsCountersInApps(list(application.getId()));
 			updateVulnerabilities(application);
 			updateScanCounts(application.getScans());
 		}

--- a/threadfix-service-interfaces/src/main/java/com/denimgroup/threadfix/service/StatisticsCounterService.java
+++ b/threadfix-service-interfaces/src/main/java/com/denimgroup/threadfix/service/StatisticsCounterService.java
@@ -35,4 +35,6 @@ public interface StatisticsCounterService {
     void updateStatistics(List<Scan> scan);
 
     void checkStatisticsCounters();
+
+    void checkStatisticsCountersInApps(List<Integer> appIds);
 }


### PR DESCRIPTION
…n tfdeploy1

This is because there's a lot of dead data in TF, so everytime it will check whole findings to map statistic counters