### PR TITLE
DGTF-1670 Cleaned up ZapAddOn.xml for the ZAP plug-in. Changed the no…

### DIFF
--- a/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapAddOn.xml
+++ b/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapAddOn.xml
@@ -1,11 +1,12 @@
 <zapaddon>
     <name>ThreadFix</name>
-    <version>1</version>
+    <version>2</version>
+    <semver/>
     <description>Export Scans to ThreadFix</description>
     <author>Denim Group (Mac Collins)</author>
-    <url></url>
+    <url/>
     <changes>First Version</changes>
-    <dependson/>
+    <dependcies/>
     <extensions>
         <extension>org.zaproxy.zap.extension.threadfix.ThreadFixExtension</extension>
     </extensions>
@@ -13,6 +14,6 @@
     <pscanrules/>
     <filters/>
     <files/>
-    <not-before-version>2.1.0</not-before-version>
+    <not-before-version>2.4.0</not-before-version>
     <not-from-version/>
 </zapaddon>

--- a/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapAddOn.xml
+++ b/threadfix-scanner-plugin/zaproxy/src/org/zaproxy/zap/extension/threadfix/ZapAddOn.xml
@@ -6,7 +6,7 @@
     <author>Denim Group (Mac Collins)</author>
     <url/>
     <changes>First Version</changes>
-    <dependcies/>
+    <dependencies/>
     <extensions>
         <extension>org.zaproxy.zap.extension.threadfix.ThreadFixExtension</extension>
     </extensions>


### PR DESCRIPTION
…t-before-version property to 2.4.0 because the current versions of ZAP (2.4.0 and 2.4.2) would not load the plug-in with lower version numbers.