### PR TITLE
DGTF-2363 Fixed the links for policies in event history descriptions.…

### DIFF
--- a/threadfix-entities/src/main/java/com/denimgroup/threadfix/data/entities/Event.java
+++ b/threadfix-entities/src/main/java/com/denimgroup/threadfix/data/entities/Event.java
@@ -786,7 +786,7 @@ public class Event extends AuditableEntity {
         if ((policy == null) || (!policy.isActive())) {
             return linkText;
         }
-        String urlString = "/configuration/acceptcriterias";
+        String urlString = "/configuration/policies";
         return buildLink(urlString, linkText, urlMap);
     }
 


### PR DESCRIPTION
… They were pointing to /configuration/acceptancecriterias.