### PR TITLE
DGTF-2450 Changed the null check for appIds in addMissingMapCounters(…

### DIFF
--- a/threadfix-importers/src/main/java/com/denimgroup/threadfix/service/StatisticsCounterServiceImpl.java
+++ b/threadfix-importers/src/main/java/com/denimgroup/threadfix/service/StatisticsCounterServiceImpl.java
@@ -79,7 +79,7 @@ public class StatisticsCounterServiceImpl implements StatisticsCounterService {
     }
 
     private void addMissingMapCounters(List<Integer> appIds) {
-        if (appIds == null || appIds.size() == 0) {
+        if (appIds != null && appIds.size() == 0) {
             LOG.debug("There were no missing map counters to add.");
             return;
         }
@@ -115,7 +115,7 @@ public class StatisticsCounterServiceImpl implements StatisticsCounterService {
     }
 
     private void addMissingFindingCounters(List<Integer> appIds) {
-        if (appIds == null || appIds.size() == 0) {
+        if (appIds != null && appIds.size() == 0) {
             LOG.debug("There were no missing finding counters to add.");
             return;
         }


### PR DESCRIPTION
…) and addMissingFindingCounters() in StatisticsCounterServiceImpl. A null input for the list is handled further down in these methods and should not be treated the same as an empty list.