### PR TITLE
DGTF-2458 Added a null check in the getFoundHAMEndpoint accessor meth…

### DIFF
--- a/threadfix-entities/src/main/java/com/denimgroup/threadfix/data/entities/Finding.java
+++ b/threadfix-entities/src/main/java/com/denimgroup/threadfix/data/entities/Finding.java
@@ -463,7 +463,7 @@ public class Finding extends AuditableEntity implements FindingLike {
 
 	@Column
 	public Boolean getFoundHAMEndpoint() {
-		return foundHAMEndpoint;
+		return foundHAMEndpoint == null ? false : foundHAMEndpoint;
 	}
 
 	public void setFoundHAMEndpoint(Boolean foundHAMEndpoint) {


### PR DESCRIPTION
…od. Null values are treated as false. This enables backwards compatability with old databases that did not have this property.