### PR TITLE
DGTF-2457 Scanner Severities -> Severities count are not correct afte…

### DIFF
--- a/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/ScanResultFilterDao.java
+++ b/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/ScanResultFilterDao.java
@@ -11,9 +11,7 @@ public interface ScanResultFilterDao extends GenericObjectDao<ScanResultFilter>{
 
     List<GenericSeverity> loadFilteredSeveritiesForChannelType(ChannelType channelType);
 
+    List<ScanResultFilter> loadAllForChannelType(ChannelType channelType);
+
     ScanResultFilter loadByChannelTypeAndSeverity(ChannelType channelType, GenericSeverity genericSeverity);
-
-    List<Integer> retrieveAllChannelSeverities();
-
-    List<Integer> retrieveAllChannelSeveritiesByChannelType(ChannelType channelType);
 }

--- a/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/StatisticsCounterDao.java
+++ b/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/StatisticsCounterDao.java
@@ -36,14 +36,9 @@ public interface StatisticsCounterDao extends GenericObjectDao<StatisticsCounter
 
     Long getCountForSeverity(int scanId, int severity);
 
-    @SuppressWarnings("unchecked")
     List<Map<String, Object>> getFindingSeverityMap(List<Integer> filteredSeverities,
                                                     List<Integer> filteredVulnerabilities,
-                                                    List<Integer> filteredChannelSeverities);
-
-    List<Map<String, Object>> getFindingSeverityMap(List<Integer> filteredSeverities,
-                                                    List<Integer> filteredVulnerabilities,
-                                                    List<Integer> filteredChannelSeverities,
+                                                    List<Integer> ignoreVulnIdsByChannelSeverities,
                                                     Scan scan);
 
     List<Map<String,Object>> getRawFindingTotalMap();

--- a/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/VulnerabilityFilterDao.java
+++ b/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/VulnerabilityFilterDao.java
@@ -23,10 +23,7 @@
 ////////////////////////////////////////////////////////////////////////
 package com.denimgroup.threadfix.data.dao;
 
-import com.denimgroup.threadfix.data.entities.GenericVulnerability;
-import com.denimgroup.threadfix.data.entities.ScanResultFilter;
-import com.denimgroup.threadfix.data.entities.SeverityFilter;
-import com.denimgroup.threadfix.data.entities.VulnerabilityFilter;
+import com.denimgroup.threadfix.data.entities.*;
 
 import java.util.List;
 import java.util.Map;
@@ -96,7 +93,9 @@ public interface VulnerabilityFilterDao {
 
 	List<Map<String, Object>> getScanReopenedVulnerabilitiesMap(List<Integer> ignoredVulnerabilityIds);
 
-	void hideForScanResultFilter(ScanResultFilter scanResultFilter);
+	void hideForScanResultFilter(ScanResultFilter scanResultFilter, Application application);
+
+	List<Integer> getVulnIdsToHide(ScanResultFilter scanResultFilter, Scan scan, Application application);
 
 	VulnerabilityFilter find(GenericVulnerability sourceGenericVulnerability, int orgId, int appId);
 

--- a/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateScanResultFilterDao.java
+++ b/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateScanResultFilterDao.java
@@ -47,6 +47,14 @@ public class HibernateScanResultFilterDao extends AbstractObjectDao<ScanResultFi
     }
 
     @Override
+    public List<ScanResultFilter> loadAllForChannelType(ChannelType channelType) {
+        Criteria criteria = sessionFactory.getCurrentSession().createCriteria(ScanResultFilter.class)
+                .add(Restrictions.eq("channelType", channelType));
+
+        return criteria.list();
+    }
+
+    @Override
     public ScanResultFilter loadByChannelTypeAndSeverity(ChannelType channelType, GenericSeverity genericSeverity) {
 
         Criteria criteria = sessionFactory.getCurrentSession().createCriteria(ScanResultFilter.class)
@@ -62,80 +70,4 @@ public class HibernateScanResultFilterDao extends AbstractObjectDao<ScanResultFi
         return scanResultFilters.get(0);
     }
 
-    // idk if this is better than just raw Java but it was fun to write
-    @Override
-    public List<Integer> retrieveAllChannelSeverities() {
-
-        List<ScanResultFilter> filters = retrieveAll();
-
-       return retrieveAllChannelSeverities(filters);
-    }
-
-    @Override
-    public List<Integer> retrieveAllChannelSeveritiesByChannelType(ChannelType channelType) {
-
-        Criteria criteria = sessionFactory.getCurrentSession().createCriteria(ScanResultFilter.class)
-                .add(Restrictions.eq("channelType", channelType));
-
-        List<ScanResultFilter> filters = criteria.list();
-        return retrieveAllChannelSeverities(filters);
-    }
-
-    private List<Integer> retrieveAllChannelSeverities(List<ScanResultFilter> filters) {
-
-        if (filters.isEmpty()) {
-            return list();
-        }
-
-        Criteria criteria = sessionFactory.getCurrentSession().createCriteria(ScanResultFilter.class)
-                .createAlias("genericSeverity", "genericSeverityAlias")
-                .createAlias("genericSeverityAlias.severityMapping", "mappingAlias")
-                .createAlias("mappingAlias.channelSeverity", "channelSeverityAlias")
-                .createAlias("channelSeverityAlias.channelType", "channelTypeAlias")
-                .setProjection(Projections.property("channelSeverityAlias.id"));
-
-        LogicalExpression wherePart = null;
-        for (ScanResultFilter filter : filters) {
-
-            if (wherePart == null) {
-                wherePart = getLogicalExpression(filter);
-            } else {
-                wherePart = Restrictions.or(wherePart, getLogicalExpression(filter));
-            }
-        }
-
-        return criteria.add(wherePart).list();
-    }
-
-    private LogicalExpression getLogicalExpression(ScanResultFilter filter) {
-
-        ChannelType alternateChannelType = filter.getChannelType();
-
-        if (alternateChannelType.getName().equals(ScannerType.APPSCAN_ENTERPRISE.getDisplayName())) {
-            alternateChannelType = retrieveChannelTypeByName(ScannerType.APPSCAN_DYNAMIC.getDisplayName());
-        }
-
-        if (alternateChannelType.getName().equals(ScannerType.DEPENDENCY_CHECK.getDisplayName())
-                || alternateChannelType.getName().equals(ScannerType.SSVL.getDisplayName())) {
-            alternateChannelType = retrieveChannelTypeByName(ScannerType.MANUAL.getDisplayName());
-        }
-
-        return Restrictions.and(
-                Restrictions.eq("genericSeverityAlias.intValue", filter.getGenericSeverity().getIntValue()),
-                Restrictions.eq("channelTypeAlias.id", alternateChannelType.getId())
-        );
-    }
-
-    private ChannelType retrieveChannelTypeByName(String name) {
-        Criteria criteria = sessionFactory.getCurrentSession().createCriteria(ChannelType.class)
-                .add(Restrictions.eq("name", name));
-
-        List<ChannelType> channelTypeList = criteria.list();
-
-        if(channelTypeList == null || channelTypeList.isEmpty()){
-            return null;
-        }
-
-        return channelTypeList.get(0);
-    }
 }

--- a/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateVulnerabilityFilterDao.java
+++ b/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateVulnerabilityFilterDao.java
@@ -425,33 +425,8 @@ public class HibernateVulnerabilityFilterDao implements VulnerabilityFilterDao {
 	}
 
 	@Override
-	public void hideForScanResultFilter(ScanResultFilter scanResultFilter) {
-		assert scanResultFilter != null;
-		assert scanResultFilter.getChannelType() != null;
-		assert scanResultFilter.getGenericSeverity() != null;
-
-		// get finding IDs first
-		List result = sessionFactory.getCurrentSession().createCriteria(Finding.class)
-				.createAlias("channelSeverity", "channelSeverityAlias")
-				.createAlias("channelSeverityAlias.severityMap", "mapAlias")
-				.createAlias("mapAlias.genericSeverity", "genericSeverityAlias")
-				.createAlias("scan", "scanAlias")
-				.createAlias("scanAlias.applicationChannel", "applicationChannelAlias")
-				.createAlias("applicationChannelAlias.channelType", "channelTypeAlias")
-				.add(Restrictions.eq("genericSeverityAlias.intValue", scanResultFilter.getGenericSeverity().getIntValue()))
-				.add(Restrictions.eq("channelTypeAlias.id", scanResultFilter.getChannelType().getId()))
-				.setProjection(Projections.property("id"))
-				.list();
-
-		if (result.isEmpty()) {
-			return;
-		}
-
-		List toHide = sessionFactory.getCurrentSession().createCriteria(Vulnerability.class)
-				.createAlias("findings", "findingsAlias")
-				.add(Restrictions.in("findingsAlias.id", result))
-				.setProjection(Projections.property("id"))
-				.list();
+	public void hideForScanResultFilter(ScanResultFilter scanResultFilter, Application application) {
+		List toHide = getVulnIdsToHide(scanResultFilter, null, application);
 
 		if (!toHide.isEmpty()) {
 			sessionFactory.getCurrentSession().createQuery(
@@ -459,6 +434,55 @@ public class HibernateVulnerabilityFilterDao implements VulnerabilityFilterDao {
 					.setParameterList("toHide", toHide)
 					.executeUpdate();
 		}
+	}
+
+	@Override
+	public List<Integer> getVulnIdsToHide(ScanResultFilter scanResultFilter, Scan scan, Application application) {
+		assert scanResultFilter != null;
+		assert scanResultFilter.getChannelType() != null;
+		assert scanResultFilter.getGenericSeverity() != null;
+
+		/*
+		There are two conditions to hide vulns:
+		1. ChannelSeverity in Finding maps to GenericSeverity in ScanResultFilter
+		2. Vulns of those Finding Ids found in step 1 have the same GenericSeverity in ScanResultFilter
+		(to avoid Vulns that users changed its severity manually or with more than one finding in Vulns)
+		 */
+
+		Criteria criteria = sessionFactory.getCurrentSession().createCriteria(Finding.class)
+				.createAlias("channelSeverity", "channelSeverityAlias")
+				.createAlias("channelSeverityAlias.severityMap", "mapAlias")
+				.createAlias("mapAlias.genericSeverity", "genericSeverityAlias")
+				.createAlias("scan", "scanAlias")
+				.createAlias("scanAlias.application", "applicationAlias")
+				.createAlias("scanAlias.applicationChannel", "applicationChannelAlias")
+				.createAlias("applicationChannelAlias.channelType", "channelTypeAlias");
+
+		if (scan != null) {
+			criteria.add(Restrictions.eq("scanAlias.id", scan.getId()));
+		}
+		if (application != null) {
+			criteria.add(Restrictions.eq("applicationAlias.id", application.getId()));
+		}
+		criteria.add(Restrictions.eq("genericSeverityAlias.intValue", scanResultFilter.getGenericSeverity().getIntValue()))
+				.add(Restrictions.eq("channelTypeAlias.id", scanResultFilter.getChannelType().getId()))
+				.setProjection(Projections.property("id"));
+
+		List result = criteria.list();
+
+		if (result.isEmpty()) {
+			return list();
+		}
+
+		List toHide = (List<Integer>)sessionFactory.getCurrentSession().createCriteria(Vulnerability.class)
+				.createAlias("findings", "findingsAlias")
+				.createAlias("genericSeverity", "genericSeverityAlias")
+				.add(Restrictions.eq("genericSeverityAlias.intValue", scanResultFilter.getGenericSeverity().getIntValue()))
+				.add(Restrictions.in("findingsAlias.id", result))
+				.setProjection(Projections.property("id"))
+				.list();
+
+		return toHide;
 	}
 
 	@Override

--- a/threadfix-importers/src/main/java/com/denimgroup/threadfix/service/merge/ScanMergerImpl.java
+++ b/threadfix-importers/src/main/java/com/denimgroup/threadfix/service/merge/ScanMergerImpl.java
@@ -86,8 +86,6 @@ public class ScanMergerImpl implements ScanMerger {
             return;
         }
 
-        filterScanResults(scan, applicationChannel);
-
         // TODO probably make all of these autowired
         Application application = applicationChannel.getApplication();
         scan.setApplicationChannel(applicationChannel);
@@ -117,28 +115,5 @@ public class ScanMergerImpl implements ScanMerger {
             permissionsHandler.setPermissions(scan, application.getId());
         }
 	}
-
-    private void filterScanResults(Scan scan, ApplicationChannel applicationChannel) {
-
-        if (scan != null && applicationChannel != null && applicationChannel.getChannelType() != null) {
-
-            List<GenericSeverity> filteredSeverities = list();
-            if (scanResultFilterService != null) {
-                filteredSeverities = scanResultFilterService.loadFilteredSeveritiesForChannelType(applicationChannel.getChannelType());
-            }
-
-            if (filteredSeverities != null && !filteredSeverities.isEmpty()) {
-                List<Finding> toFilter = list();
-
-                for (Finding finding : scan.getFindings()) {
-                    if (filteredSeverities.contains(finding.getChannelSeverity().getSeverityMap().getGenericSeverity())) {
-                        toFilter.add(finding);
-                    }
-                }
-
-                scan.getFindings().removeAll(toFilter);
-            }
-        }
-    }
 
 }

--- a/threadfix-main/src/main/java/com/denimgroup/threadfix/service/ScanResultFilterServiceImpl.java
+++ b/threadfix-main/src/main/java/com/denimgroup/threadfix/service/ScanResultFilterServiceImpl.java
@@ -22,9 +22,6 @@ public class ScanResultFilterServiceImpl implements ScanResultFilterService{
     private ScanResultFilterDao scanResultFilterDao;
 
     @Autowired
-    private VulnerabilityService vulnerabilityService;
-
-    @Autowired
     private FindingService findingService;
 
     @Autowired
@@ -42,24 +39,7 @@ public class ScanResultFilterServiceImpl implements ScanResultFilterService{
 
     @Override
     public void storeAndApplyFilter(ScanResultFilter scanResultFilter, GenericSeverity previousGenericSeverity, ChannelType previousChannelType) {
-
-        if(previousGenericSeverity != null && previousChannelType != null
-                && (!scanResultFilter.getGenericSeverity().equals(previousGenericSeverity) || !scanResultFilter.getChannelType().equals(previousChannelType))){
-
-            unFilterFindings(previousGenericSeverity, previousChannelType);
-        }
-
         scanResultFilterDao.saveOrUpdate(scanResultFilter);
-
-        List<Finding> findingsToFilter = findingService.loadByGenericSeverityAndChannelType(scanResultFilter.getGenericSeverity(), scanResultFilter.getChannelType());
-
-        if(findingsToFilter != null && !findingsToFilter.isEmpty()){
-            for(Finding finding : findingsToFilter){
-                finding.setHidden(true);
-                findingService.storeFinding(finding);
-            }
-        }
-
         vulnerabilityFilterService.updateAllVulnerabilities();
     }
 

--- a/threadfix-main/src/main/java/com/denimgroup/threadfix/service/VulnerabilityFilterServiceImpl.java
+++ b/threadfix-main/src/main/java/com/denimgroup/threadfix/service/VulnerabilityFilterServiceImpl.java
@@ -222,6 +222,8 @@ public class VulnerabilityFilterServiceImpl implements VulnerabilityFilterServic
 
 		vulnerabilityFilterDao.applySeverityFilterToApplication(appId, severityFilter);
 
+		applyChannelSeverityFilters(application);
+
 		vulnerabilityService.updateVulnerabilityReport(
 				applicationService.loadApplication(appId)
 		);
@@ -476,7 +478,7 @@ public class VulnerabilityFilterServiceImpl implements VulnerabilityFilterServic
 		List<ScanResultFilter> scanResultFilters = scanResultFilterService.loadAll();
 
 		for (ScanResultFilter scanResultFilter : scanResultFilters) {
-			vulnerabilityFilterDao.hideForScanResultFilter(scanResultFilter);
+			vulnerabilityFilterDao.hideForScanResultFilter(scanResultFilter, application);
 		}
 	}
 


### PR DESCRIPTION
…r creating a rule to suppress a severity level

/*
+		There are two conditions to hide vulns:
+		1. ChannelSeverity in Finding maps to GenericSeverity in ScanResultFilter
+		2. Vulns of those Finding Ids found in step 1 have the same GenericSeverity in ScanResultFilter
+		(to avoid Vulns that users changed its severity manually or with more than one finding in Vulns)
+		 */