### PR TITLE
Modifies IDs in the reports to be more flexible with custom names for…

### DIFF
--- a/threadfix-main/src/main/webapp/scripts/report/d3-donut.js
+++ b/threadfix-main/src/main/webapp/scripts/report/d3-donut.js
@@ -177,8 +177,8 @@ angular.module('threadfix')
                 .append("g")
                 .attr("class", "arc pointer")
                 .attr("id", function(d){
-                    var str = (d.data.teamName)? d.data.teamName : "pointInTime";
-                    return str + d.data.severity + "Arc";
+                    var str = (d.data.teamName)? "arc" + d.data.teamName : "pointInTime";
+                    return str + d.data.severity;
                 })
                 .append("path")
                 .style("fill", function(d) { return d.data.fillColor; })

--- a/threadfix-main/src/main/webapp/scripts/report/directives/d3-dashboards.js
+++ b/threadfix-main/src/main/webapp/scripts/report/directives/d3-dashboards.js
@@ -346,7 +346,7 @@ function barGraphData(d3, data, color, isLeftReport, label, reportConstants, tex
                 appId: (label && label.appId) ? label.appId : d.appId,
                 appName: d.appName,
                 severity: (topVulnsReport) ? undefined : key,
-                graphId: d.teamName + d.appName + ((topVulnsReport)? "CWE" + d.displayId : tip) + "Bar",
+                graphId: "bar" + d.teamName + d.appName + ((topVulnsReport)? "CWE" + d.displayId : tip),
                 genericSeverities: d.genericSeverities
             };
         });

--- a/threadfix-main/src/main/webapp/scripts/report/directives/d3-trending-scans.js
+++ b/threadfix-main/src/main/webapp/scripts/report/directives/d3-trending-scans.js
@@ -299,7 +299,7 @@ d3ThreadfixModule.directive('d3Trending', ['d3', 'reportExporter', 'reportUtilit
                             .enter().insert("path", ".line")
                             .attr("class", "area")
                             .attr("id", function(){
-                                return d.key + "Area";
+                                return "area" + d.key;
                             })
                             .style("fill", "white")
                             .transition()
@@ -337,7 +337,7 @@ d3ThreadfixModule.directive('d3Trending', ['d3', 'reportExporter', 'reportUtilit
                             .duration(duration)
                             .attr('fill', getColor(d.key))
                             .attr("id", function(){
-                                return d.key + "Text";
+                                return "text" + d.key;
                             })
                             .text(d.key)
                             .attr("transform", function() {
@@ -400,7 +400,7 @@ d3ThreadfixModule.directive('d3Trending', ['d3', 'reportExporter', 'reportUtilit
                                     y1: 0,
                                     y2: h	})
                                 .attr("class", "versionLine")
-                                .attr("id", version.id)
+                                .attr("id", "version" + version.name)
                         });
                     }
                 };
@@ -454,7 +454,7 @@ d3ThreadfixModule.directive('d3Trending', ['d3', 'reportExporter', 'reportUtilit
                     if (showScan) {
                         focusCircles.attr('transform', function (d) {
                             time = d.values[i].date;
-                            tips.push("<tr><td>" + d.key + "&nbsp;</td> <td style='color:"+ getTextColor(d.key) +"'>" + d.values[i].noOfVulns + "</td></tr>");
+                            tips.push("<tr><td id='areaTip" + d.key + "'>" + d.key + "&nbsp;</td> <td style='color:"+ getTextColor(d.key) +"'>" + d.values[i].noOfVulns + "</td></tr>");
 
                             focus.selectAll('path').remove();
                             focus.append("path")
@@ -496,7 +496,7 @@ d3ThreadfixModule.directive('d3Trending', ['d3', 'reportExporter', 'reportUtilit
                                 y1: 0,
                                 y2: h	})
                             .attr("class", "versionLineFocus")
-                            .attr("id", filterVersions[j].id + "focus");
+                            .attr("id", "version" + filterVersions[j].name + "focus");
 
                         tip.show(svg.selectAll(".versionLineFocus")[0][0]);
                     }


### PR DESCRIPTION
… tests
Most of these changes serve to ensure that an ID cannot start with a number if a custom severity name starts with one.  These changes will help in testing custom severity names more thoroughly.