### PR TITLE
DGTF-2636 allow rename to non-used names

### DIFF
--- a/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/GenericSeverityDao.java
+++ b/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/GenericSeverityDao.java
@@ -31,5 +31,5 @@ public interface GenericSeverityDao extends GenericNamedObjectDao<GenericSeverit
 
     GenericSeverity retrieveByIntValue(int iValue);
 
-    boolean doesCustomNameExist(String customName, int severityId);
+    boolean doesSeverityNameExist(String customName, int severityId);
 }

--- a/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateGenericSeverityDao.java
+++ b/threadfix-data-access/src/main/java/com/denimgroup/threadfix/data/dao/hibernate/HibernateGenericSeverityDao.java
@@ -60,11 +60,13 @@ public class HibernateGenericSeverityDao
     }
 
 	@Override
-	public boolean doesCustomNameExist(String customName, int severityId){
+	public boolean doesSeverityNameExist(String customName, int severityId){
 		return !sessionFactory.getCurrentSession()
 				.createCriteria(GenericSeverity.class)
 				.add(Restrictions.ne("id",severityId))
-				.add(Restrictions.or(Restrictions.eq("customName", customName),Restrictions.eq("name",customName)))
+				.add(Restrictions.or(Restrictions.eq("customName", customName),
+						Restrictions.and(Restrictions.eq("name",customName),
+								Restrictions.or(Restrictions.eq("customName",""),Restrictions.isNull("customName")))))
 				.list().isEmpty();
 	}
 }

--- a/threadfix-main/src/main/java/com/denimgroup/threadfix/service/GenericSeverityServiceImpl.java
+++ b/threadfix-main/src/main/java/com/denimgroup/threadfix/service/GenericSeverityServiceImpl.java
@@ -50,10 +50,9 @@ public class GenericSeverityServiceImpl
 	@Override
 	public boolean canSetCustomNameTo(int genericSeverityId, String text) {
 		if ("".equals(text)) {
-			return true; // it's ok to clear the custom text
+			text = loadById(genericSeverityId).getName();
 		}
-
-		return !genericSeverityDao.doesCustomNameExist(text,genericSeverityId);
+		return !genericSeverityDao.doesSeverityNameExist(text,genericSeverityId);
 	}
 
 	@Override


### PR DESCRIPTION
Allows a severity name to be changed to any name that is not currently in use.