### PR TITLE
null checked url and added placeholder

### DIFF
--- a/threadfix-importers/src/main/java/com/denimgroup/threadfix/importer/impl/remoteprovider/ContrastRemoteProvider.java
+++ b/threadfix-importers/src/main/java/com/denimgroup/threadfix/importer/impl/remoteprovider/ContrastRemoteProvider.java
@@ -361,7 +361,7 @@ public class ContrastRemoteProvider extends AbstractRemoteProvider {
 
     private String getContrastBaseUrl() {
         for (RemoteProviderAuthenticationField authField : remoteProviderType.getAuthenticationFields()) {
-            if (authField.getName().equals("URL")){
+            if (authField.getName().equals("URL") && authField.getValue() != null && !authField.getValue().isEmpty()){
                 return authField.getValue();
             }
         }

--- a/threadfix-importers/src/main/resources/mappings/remoteprovider/contrast.csv
+++ b/threadfix-importers/src/main/resources/mappings/remoteprovider/contrast.csv
@@ -1,4 +1,4 @@
-11/30/2015 14:30:00
+01/04/2016 12:50:00
 type.name
 Contrast,http://www1.contrastsecurity.com/,1,Use as a Remote Provider
 type.credentials
@@ -9,4 +9,4 @@ type.authenticationfields
 Username,false,true
 API Key,true,true
 Service Key,true,true
-URL,false,false
+URL,false,false,https://app.contrastsecurity.com


### PR DESCRIPTION
if contrast remote provider url is null it will now use the default url