### PR TITLE
Corrects error in filter used for IDs

### DIFF
--- a/threadfix-main/src/main/webapp/scripts/filters.js
+++ b/threadfix-main/src/main/webapp/scripts/filters.js
@@ -60,7 +60,11 @@ filtersModule.filter('pivotForID', function() {
             return test2[1].replace(/\W/g, '');
         }
 
-        return input.replace(/\W/g, '');
+        if (input) {
+            return input.replace(/\W/g, '');
+        }
+
+        return input;
     }
 });
 


### PR DESCRIPTION
The comment elements on a Vulnerability Detail page did not have pivot information to pass in, so this filter was trying to replace text that didn't exist.  This led to errors that prevented the elements from having any value display for their ID.